### PR TITLE
Fix session timeout

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -2522,7 +2522,7 @@ PS_WRITE_FUNC(memcached)
 	memcached_st *memc_sess = PS_GET_MOD_DATA();
 
 	sess_key_len = spprintf(&sess_key, 0, "memc.sess.key.%s", key);
-	sess_lifetime = zend_ini_long(ZEND_STRL("session.gc_maxlifetime"), 0);
+	sess_lifetime = zend_ini_long("session.gc_maxlifetime", sizeof("session.gc_maxlifetime"), 0);
 	if (sess_lifetime > 0) {
 		expiration = time(NULL) + sess_lifetime;
 	} else {


### PR DESCRIPTION
This commit fixes a bug where the ini file is incorrectly parsed resulting in the session ttl always being set to 0.
This leads to never expiring sessions, bloating memcached usage. This is particularly troublesome when using
CouchBase as a memcached replacement as sessions never expire, consuming all CouchBase's disk storage.

Markus Berthold found and fixed the bug. For more details, see:
http://www.couchbase.org/forums/thread/using-membase-php-session-handler

I think a new release of the 1.0 branch is warranted as the 2.0 branch has API changes (such as return null instead of false when a value isn't found).
