### PR TITLE
Fixes an incorrect libmemcached version check for OPT_PREFIX_KEY

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -2171,7 +2171,7 @@ static PHP_METHOD(Memcached, getOption)
 
 			result = memcached_callback_get(m_obj->memc, MEMCACHED_CALLBACK_PREFIX_KEY, &retval);
 			if (retval == MEMCACHED_SUCCESS) {
-#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX < 0x00050000
+#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX == 0x00049000
 				RETURN_STRINGL(result, strlen(result) - 1,  1);
 #else
 				RETURN_STRING(result, 1);
@@ -2228,7 +2228,7 @@ static int php_memc_set_option(php_memc_t *i_obj, long option, zval *value TSRML
 		case MEMC_OPT_PREFIX_KEY:
 		{
 			char *key;
-#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX < 0x00050000
+#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX == 0x00049000
 			char tmp[MEMCACHED_PREFIX_KEY_MAX_SIZE - 1];
 #endif
 			convert_to_string(value);
@@ -2236,10 +2236,10 @@ static int php_memc_set_option(php_memc_t *i_obj, long option, zval *value TSRML
 				key = NULL;
 			} else {
 				/*
-				   work-around a bug in libmemcached prior to version 0.50 that truncates the trailing
+				   work-around a bug in libmemcached version 0.49 that truncates the trailing
 				   character of the key prefix, to avoid the issue we pad it with a '0'
 				*/
-#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX < 0x00050000
+#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX == 0x00049000
 				snprintf(tmp, sizeof(tmp), "%s0", Z_STRVAL_P(value));
 				key = tmp;
 #else


### PR DESCRIPTION
The PREFIX_KEY functionality had a comment explaining that a bug
had to be worked around, in all version prior to 0.50.  However,
that assumption was invalid, as the memcached_set_prefix_key()
behavior was only rewritten in version 0.49.  Since the error was
fixed in libmemcached-0.50, that means it only exists in one version:
0.49.

I tested this fix against every release between 0.44 - 0.50, and
confirmed that the bug only has to be worked around in _exactly_
version 0.49.

The simple test:

```
[terminalA] $ nc -l localhost 5555

[terminalB] $ php -a
php > $mc = new Memcached();
php > $mc->addServer('localhost', 5555, 1);
php > $mc->setOption(Memcached::OPT_PREFIX_KEY, 'foo');
php > $mc->set('bar', 1, 15);
```

I saw "foo0bar" coming through in version 0.44 - 0.48. The problem
was fixed in 0.49 and 0.50.
