### PR TITLE
add consistent hashing option for session handling

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -17,6 +17,14 @@ memcached.sess_lock_wait = 150000
 ; the default value is "memc.sess.key."
 memcached.sess_prefix = "memc.sess.key."
 
+; memcached session consistent hash mode
+; if set to On, consistent hashing (libketama) is used
+; for session handling.
+; When consistent hashing is used, one can add or remove cache
+; node(s) without messing up too much with existing keys
+; default is Off
+memcached.sess_consistent_hash = Off
+
 ; memcached session binary mode
 memcached.sess_binary = Off
 

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -287,6 +287,7 @@ static PHP_INI_MH(OnUpdateSerializer)
 PHP_INI_BEGIN()
 #ifdef HAVE_MEMCACHED_SESSION
 	STD_PHP_INI_ENTRY("memcached.sess_locking",		"1",		PHP_INI_ALL, OnUpdateBool,		sess_locking_enabled,	zend_php_memcached_globals,	php_memcached_globals)
+	STD_PHP_INI_ENTRY("memcached.sess_consistent_hash",	"0",		PHP_INI_ALL, OnUpdateBool,		sess_consistent_hash_enabled,	zend_php_memcached_globals,	php_memcached_globals)
 	STD_PHP_INI_ENTRY("memcached.sess_binary",		"0",		PHP_INI_ALL, OnUpdateBool,		sess_binary_enabled,	zend_php_memcached_globals,	php_memcached_globals)
 	STD_PHP_INI_ENTRY("memcached.sess_lock_wait",		"150000",	PHP_INI_ALL, OnUpdateLongGEZero,sess_lock_wait,			zend_php_memcached_globals,	php_memcached_globals)
 	STD_PHP_INI_ENTRY("memcached.sess_prefix",		"memc.sess.key.",	PHP_INI_ALL, OnUpdateString, sess_prefix,		zend_php_memcached_globals,	php_memcached_globals)

--- a/php_memcached.h
+++ b/php_memcached.h
@@ -78,6 +78,7 @@ ZEND_BEGIN_MODULE_GLOBALS(php_memcached)
 #if HAVE_MEMCACHED_SASL
 	bool use_sasl;
 #endif
+	zend_bool sess_consistent_hash_enabled;
 	zend_bool sess_binary_enabled;
 ZEND_END_MODULE_GLOBALS(php_memcached)
 

--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -140,6 +140,18 @@ error:
 		if (servers) {
 			memc_sess->memc_sess = memcached_create(NULL);
 			if (memc_sess->memc_sess) {
+				if (MEMC_G(sess_consistent_hash_enabled)) {
+					if (memcached_behavior_set(memc_sess->memc_sess, MEMCACHED_BEHAVIOR_KETAMA_WEIGHTED, (uint64_t) 1) == MEMCACHED_FAILURE) {
+						PS_SET_MOD_DATA(NULL);
+						if (plist_key) {
+							efree(plist_key);
+						}
+						memcached_free(memc_sess->memc_sess);
+						php_error_docref(NULL TSRMLS_CC, E_WARNING, "failed to enable memcached consistent hashing");
+						return FAILURE;
+					}
+				}
+
 				status = memcached_server_push(memc_sess->memc_sess, servers);
 				memcached_server_list_free(servers);
 


### PR DESCRIPTION
Hi,

I added an option to enable consistent hashing for session handling, in order to use a big pool of small cache instances and add or remove quite frequently some instances without messing up the whole set of existing sessions.
This can be enabled using memcached.sess_consistent_hash ini boolean, and enables MEMCACHED_BEHAVIOR_KETAMA_WEIGHTED.
