### PR TITLE
Fixed tests after chanage to php_memc_do_serverlist_callback()

### DIFF
--- a/tests/bug_16084.phpt
+++ b/tests/bug_16084.phpt
@@ -13,12 +13,10 @@ var_dump($m->getServerList());
 bool(true)
 array(1) {
   [0]=>
-  array(3) {
+  array(2) {
     ["host"]=>
     string(9) "localhost"
     ["port"]=>
     int(11211)
-    ["weight"]=>
-    int(3)
   }
 }

--- a/tests/getserverlist.phpt
+++ b/tests/getserverlist.phpt
@@ -20,43 +20,35 @@ array(0) {
 }
 array(1) {
   [0]=>
-  array(3) {
+  array(2) {
     ["host"]=>
     string(9) "localhost"
     ["port"]=>
     int(11211)
-    ["weight"]=>
-    int(3)
   }
 }
 array(2) {
   [0]=>
-  array(3) {
+  array(2) {
     ["host"]=>
     string(9) "localhost"
     ["port"]=>
     int(11211)
-    ["weight"]=>
-    int(3)
   }
   [1]=>
-  array(3) {
+  array(2) {
     ["host"]=>
     string(9) "localhost"
     ["port"]=>
     int(11211)
-    ["weight"]=>
-    int(3)
   }
 }
 array(1) {
   [0]=>
-  array(3) {
+  array(2) {
     ["host"]=>
     string(9) "127.0.0.1"
     ["port"]=>
     int(11211)
-    ["weight"]=>
-    int(%r[01]%r)
   }
 }

--- a/tests/invoke_callback.phpt
+++ b/tests/invoke_callback.phpt
@@ -19,13 +19,11 @@ echo "OK\n";
 --EXPECTF--
 array(1) {
   [0]=>
-  array(3) {
+  array(2) {
     ["host"]=>
     string(9) "127.0.0.1"
     ["port"]=>
     int(11211)
-    ["weight"]=>
-    int(%r[01]%r)
   }
 }
 OK


### PR DESCRIPTION
The php function getServerList() no longer returns a weight value. The tests have been updated to reflect this change.

The need for this change is result of commenting out "add_assoc_long(array, "weight", instance->weight);" in php_memcached.c
