### PR TITLE
Removed memcached.sess_consistent_hashing option. Fix for issue #53

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -292,7 +292,6 @@ PHP_INI_BEGIN()
 
 	STD_PHP_INI_ENTRY("memcached.sess_number_of_replicas",	"0",	PHP_INI_ALL, OnUpdateLongGEZero,	sess_number_of_replicas,	zend_php_memcached_globals,	php_memcached_globals)
 	STD_PHP_INI_ENTRY("memcached.sess_randomize_replica_read",	"0",	PHP_INI_ALL, OnUpdateBool,	sess_randomize_replica_read,	zend_php_memcached_globals,	php_memcached_globals)
-	STD_PHP_INI_ENTRY("memcached.sess_consistent_hashing",	"0",		PHP_INI_ALL, OnUpdateBool,              sess_consistent_hashing_enabled,	zend_php_memcached_globals,     php_memcached_globals)
 	STD_PHP_INI_ENTRY("memcached.sess_remove_failed",	"0",		PHP_INI_ALL, OnUpdateBool,              sess_remove_failed_enabled,	zend_php_memcached_globals,     php_memcached_globals)
 #endif
 	STD_PHP_INI_ENTRY("memcached.compression_type",		"fastlz",	PHP_INI_ALL, OnUpdateCompressionType, compression_type,		zend_php_memcached_globals,	php_memcached_globals)
@@ -3042,7 +3041,7 @@ static void php_memc_init_globals(zend_php_memcached_globals *php_memcached_glob
 #ifdef HAVE_MEMCACHED_SESSION
 	MEMC_G(sess_locking_enabled) = 1;
 	MEMC_G(sess_binary_enabled) = 1;
-	MEMC_G(sess_consistent_hashing_enabled) = 0;
+	MEMC_G(sess_consistent_hash_enabled) = 0;
 	MEMC_G(sess_number_of_replicas) = 0;
 	MEMC_G(sess_remove_failed_enabled) = 0;
 	MEMC_G(sess_prefix) = NULL;

--- a/php_memcached.h
+++ b/php_memcached.h
@@ -70,7 +70,8 @@ ZEND_BEGIN_MODULE_GLOBALS(php_memcached)
 	int   sess_number_of_replicas;
 	zend_bool sess_randomize_replica_read;
 	zend_bool sess_remove_failed_enabled;
-	zend_bool sess_consistent_hashing_enabled;
+	zend_bool sess_consistent_hash_enabled;
+	zend_bool sess_binary_enabled;
 #endif
 	char *serializer_name;
 	enum memcached_serializer serializer;
@@ -83,8 +84,6 @@ ZEND_BEGIN_MODULE_GLOBALS(php_memcached)
 #if HAVE_MEMCACHED_SASL
 	bool use_sasl;
 #endif
-	zend_bool sess_consistent_hash_enabled;
-	zend_bool sess_binary_enabled;
 ZEND_END_MODULE_GLOBALS(php_memcached)
 
 PHP_MEMCACHED_API zend_class_entry *php_memc_get_ce(void);

--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -228,13 +228,6 @@ success:
 				}
 			}
 
-			if (MEMC_G(sess_consistent_hashing_enabled)) {
-				if (memcached_behavior_set(memc_sess->memc_sess, MEMCACHED_BEHAVIOR_KETAMA, (uint64_t) 1) == MEMCACHED_FAILURE) {
-					php_error_docref(NULL TSRMLS_CC, E_WARNING, "failed to set memcached consistent hashing");
-					return FAILURE;
-				}
-			}
-
 			/* Allow libmemcached remove failed servers */
 			if (MEMC_G(sess_remove_failed_enabled)) {
 				if (memcached_behavior_set(memc_sess->memc_sess, MEMCACHED_BEHAVIOR_REMOVE_FAILED_SERVERS, (uint64_t) 1) == MEMCACHED_FAILURE) {

--- a/tests/experimental/moduleinfo.phpt
+++ b/tests/experimental/moduleinfo.phpt
@@ -25,7 +25,6 @@ memcached.compression_type => %s => %s
 memcached.serializer => %s => %s
 memcached.sess_binary => %d => %d
 memcached.sess_consistent_hash => %d => %d
-memcached.sess_consistent_hashing => %d => %d
 memcached.sess_lock_wait => %d => %d
 memcached.sess_locking => %d => %d
 memcached.sess_number_of_replicas => %d => %d


### PR DESCRIPTION
Fix for issue #53
1. Removed memcached.sess_consistent_hashing which is a lesser version  of memcached.sess_consistent_hash
2. Added default value for memcached.sess_consistent_hash
