### PR TITLE
Removed unused memcached.ini option

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -35,14 +35,11 @@ memcached.sess_remove_failed = 1
 ; from a replica. However, if the failed memcache server
 ; becomes available again it will read the session from there
 ; which could have old data or no data at all
-memcached.sess_num_replicas = 0;
+memcached.sess_number_of_replicas = 0
 
 ; memcached session binary mode
 ; libmemcached replicas only work if binary mode is enabled
 memcached.sess_binary = Off
-
-; memcached session number of replicas
-memcached.sess_number_of_replicas = 0
 
 ; memcached session replica read randomize
 memcached.sess_randomize_replica_read = Off


### PR DESCRIPTION
After the merge of commits 5ff9516240 and faf84af789
the memcached.sess_num_replicas option is no longer exists.
The ini option is called memcached.sess_num_replicas
