### PR TITLE
Fixed compatibility with libmemcached 1.0.8

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -2730,7 +2730,7 @@ static memcached_return php_memc_do_version_callback(const memcached_st *ptr, me
 	struct callbackContext* context = (struct callbackContext*) in_context;
 
 	hostport_len = spprintf(&hostport, 0, "%s:%d", memcached_server_name(instance), memcached_server_port(instance));
-#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX >= 0x01000008
+#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX >= 0x01000009
 	version_len = snprintf(version, sizeof(version), "%d.%d.%d",
 				memcached_server_major_version(instance),
 				memcached_server_minor_version(instance),


### PR DESCRIPTION
Fixed execution with libmemcached 1.0.8.
It was throwing: "undefined symbol: memcached_server_micro_version in Unknown on line 0"
That symbol has been introduced in libmemcached 1.0.9, not 1.0.8.
I checked the libmemcached sources here:
https://launchpad.net/libmemcached/+download
