### PR TITLE
Memcached::get() always return NOT_FOUND on error

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -600,6 +600,13 @@ static void php_memc_get_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 			return;
 		}
 	}
+	
+	/* Fetch all remaining results */
+	memcached_result_st dummy_result;
+	memcached_return dummy_status = MEMCACHED_SUCCESS;
+	memcached_result_create(m_obj->memc, &dummy_result);
+	while (memcached_fetch_result(m_obj->memc, &dummy_result, &dummy_status) != NULL) {}
+	memcached_result_free(&dummy_result);
 
 	payload     = memcached_result_value(&result);
 	payload_len = memcached_result_length(&result);


### PR DESCRIPTION
From https://github.com/php-memcached-dev/php-memcached/issues/9

```
<?php

$memcached = new Memcached();
$memcached->addServer('localhost', 5555); // Server should not exist

$result = $memcached->get('foo');
echo $memcached->getResultMessage() . "\n";
```

Result: `NOT FOUND`
Expected: `SERVER IS MARKED DEAD`

Note: `$memcached->get('foo', null, $cas)` works.
