### PR TITLE
Ensure that Memcached::get fetches all results available

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -600,6 +600,13 @@ static void php_memc_get_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 			return;
 		}
 	}
+	
+	/* Fetch all remaining results */
+	memcached_result_st dummy_result;
+	memcached_return dummy_status = MEMCACHED_SUCCESS;
+	memcached_result_create(m_obj->memc, &dummy_result);
+	while (memcached_fetch_result(m_obj->memc, &dummy_result, &dummy_status) != NULL) {}
+	memcached_result_free(&dummy_result);
 
 	payload     = memcached_result_value(&result);
 	payload_len = memcached_result_length(&result);


### PR DESCRIPTION
This supersedes pull request #4 taking advantage of the improvements made by @blat in pull request #74. This resolves the bug described in issue #14.

Previously only the first result was fetched after the memcached_mget_by_key call resulting in a RES_END result being left on the stack. As per the [libmemcached documentation](http://docs.libmemcached.org/memcached_get.html#description) memcached_fetch_result should be called until it returns NULL following a multi-get.

In some circumstances this is not noticeable as libmemcached takes care of flushing the receive buffers accordingly, however certain subsequent operations will incorrectly return the left-over RES_END result.
