### PR TITLE
More granular session locking support

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -12,6 +12,18 @@ memcached.sess_locking = On
 ; the default is 150000
 memcached.sess_lock_wait = 150000
 
+; The maximum time, in seconds, to wait for a session lock
+; before timing out.
+; Setting to 0 results in default behavior, which is to
+; use max_execution_time.
+memcached.sess_lock_max_wait = 0;
+
+; The time, in seconds, before a lock should release itself.
+; Setting to 0 results in the default behaviour, which is to
+; use the memcached.sess_lock_max_wait setting. If that is
+; also 0, max_execution_time will be used.
+memcached.sess_lock_expire = 0;
+
 ; memcached session key prefix
 ; valid values are strings less than 219 bytes long
 ; the default value is "memc.sess.key."

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -295,6 +295,8 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("memcached.sess_consistent_hash",	"0",		PHP_INI_ALL, OnUpdateBool,		sess_consistent_hash_enabled,	zend_php_memcached_globals,	php_memcached_globals)
 	STD_PHP_INI_ENTRY("memcached.sess_binary",		"0",		PHP_INI_ALL, OnUpdateBool,		sess_binary_enabled,	zend_php_memcached_globals,	php_memcached_globals)
 	STD_PHP_INI_ENTRY("memcached.sess_lock_wait",		"150000",	PHP_INI_ALL, OnUpdateLongGEZero,sess_lock_wait,			zend_php_memcached_globals,	php_memcached_globals)
+	STD_PHP_INI_ENTRY("memcached.sess_lock_max_wait",		"0",	PHP_INI_ALL, OnUpdateLongGEZero, sess_lock_max_wait,			zend_php_memcached_globals,	php_memcached_globals)
+	STD_PHP_INI_ENTRY("memcached.sess_lock_expire",		"0",	PHP_INI_ALL, OnUpdateLongGEZero, sess_lock_expire,			zend_php_memcached_globals,	php_memcached_globals)
 	STD_PHP_INI_ENTRY("memcached.sess_prefix",		"memc.sess.key.",	PHP_INI_ALL, OnUpdateString, sess_prefix,		zend_php_memcached_globals,	php_memcached_globals)
 
 	STD_PHP_INI_ENTRY("memcached.sess_number_of_replicas",	"0",	PHP_INI_ALL, OnUpdateLongGEZero,	sess_number_of_replicas,	zend_php_memcached_globals,	php_memcached_globals)
@@ -3155,6 +3157,8 @@ static void php_memc_init_globals(zend_php_memcached_globals *php_memcached_glob
 	MEMC_G(sess_remove_failed_enabled) = 0;
 	MEMC_G(sess_prefix) = NULL;
 	MEMC_G(sess_lock_wait) = 0;
+	MEMC_G(sess_lock_max_wait) = 0;
+	MEMC_G(sess_lock_expire) = 0;
 	MEMC_G(sess_locked) = 0;
 	MEMC_G(sess_lock_key) = NULL;
 	MEMC_G(sess_lock_key_len) = 0;

--- a/php_memcached.h
+++ b/php_memcached.h
@@ -62,6 +62,8 @@ ZEND_BEGIN_MODULE_GLOBALS(php_memcached)
 #ifdef HAVE_MEMCACHED_SESSION
 	zend_bool sess_locking_enabled;
 	long  sess_lock_wait;
+	long  sess_lock_max_wait;
+	long  sess_lock_expire;
 	char* sess_prefix;
 	zend_bool sess_locked;
 	char* sess_lock_key;


### PR DESCRIPTION
Adding memcached.sess_lock_max_wait, which sets how long
a incoming lock request will wait for the lock before
dying.

And memcached.sess_lock_expire, which sets how long until
the lock expires, independent of the current
max_execution_time.
