### PR TITLE
Fixes issue #93

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3053,6 +3053,11 @@ static int php_memc_zval_from_payload(zval *value, const char *payload_in, size_
 
 		case MEMC_VAL_IS_LONG:
 		{
+			if (payload_len >= 128) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "could not read long value, too big");
+				goto my_error;
+			}
+
 			char conv_buf [128];
 			memcpy (conv_buf, pl, payload_len);
 			conv_buf [payload_len] = '\0';
@@ -3064,6 +3069,11 @@ static int php_memc_zval_from_payload(zval *value, const char *payload_in, size_
 
 		case MEMC_VAL_IS_DOUBLE:
 		{
+			if (payload_len >= 128) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "could not read double value, too big");
+				goto my_error;
+			}
+
 			char conv_buf [128];
 			memcpy (conv_buf, pl, payload_len);
 			conv_buf [payload_len] = '\0';

--- a/tests/gh_93.phpt
+++ b/tests/gh_93.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test for Github issue #93 (double and long overflow)
+--SKIPIF--
+<?php if (!extension_loaded("memcached")) print "skip"; ?>
+--FILE--
+<?php
+$m = new Memcached();
+$m->addServer('127.0.0.1', 11211, 1);
+$m->setOption(Memcached::OPT_COMPRESSION, false);
+
+function testOverflow($m, $value) {
+	$m->delete('overflow');
+	if (true !== $m->set('overflow', $value)) {
+		echo "Error storing 'overflow' variable\n";
+		return false;
+	}
+
+	if (true !== $m->prepend('overflow', str_repeat('0', 128))) {
+		echo "Error prepending key\n";
+		return false;
+	}
+
+	$v = @$m->get('overflow');
+	if ($v !== $value) {
+		// At least it doesn't segfault, so we're happy for now
+		// echo "Error receiving 'overflow' variable\n";
+		// return false;
+		return true;
+	}
+
+	return true;
+}
+
+if (!testOverflow($m, 10)) {
+	return;
+}
+
+if (!testOverflow($m, 9.09)) {
+	return;
+}
+
+echo "OK\n";
+?>
+--EXPECT--
+OK


### PR DESCRIPTION
Protect against stack overflow in php_memc_zval_from_payload when parsing DOUBLE or LONG
