### PR TITLE
Fix compression on big-endian architecture

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3084,9 +3084,10 @@ char *s_compress_value (enum memcached_compression_type compression_type, const 
 
 	/* Store compressed size here */
 	size_t compressed_size = 0;
+    uint32_t plen = *payload_len;
 
 	/* Copy the uin32_t at the beginning */
-	memcpy(buffer, payload_len, sizeof(uint32_t));
+	memcpy(buffer, &plen, sizeof(uint32_t));
 	buffer += sizeof(uint32_t);
 
 	switch (compression_type) {


### PR DESCRIPTION
On big-endian architecture where size_t is a 64-bit long,
copying the 4 first bytes as the size is incorrect. We cast it to an
unsigned 32-bit integer before copying it at the beginning of the
provided buffer.
