### PR TITLE
Use new session save handler

### DIFF
--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -326,6 +326,8 @@ PS_READ_FUNC(memcached)
 		*val = zend_string_init(payload, payload_len, 1);
 		free(payload);
 		return SUCCESS;
+	} else if (status = MEMCACHED_NOTFOUND) {
+		*val = ZSTR_EMPTY_ALLOC();
 	} else {
 		return FAILURE;
 	}

--- a/php_memcached_session.h
+++ b/php_memcached_session.h
@@ -24,7 +24,7 @@
 extern ps_module ps_mod_memcached;
 #define ps_memcached_ptr &ps_mod_memcached
 
-PS_FUNCS(memcached);
+PS_FUNCS_UPDATE_TIMESTAMP(memcached);
 
 PS_OPEN_FUNC(memcached);
 PS_CLOSE_FUNC(memcached);
@@ -32,5 +32,8 @@ PS_READ_FUNC(memcached);
 PS_WRITE_FUNC(memcached);
 PS_DESTROY_FUNC(memcached);
 PS_GC_FUNC(memcached);
+PS_CREATE_SID_FUNC(memcached);
+PS_VALIDATE_SID_FUNC(memcached);
+PS_UPDATE_TIMESTAMP_FUNC(memcached);
 
 #endif /* PHP_MEMCACHED_SESSION_H */

--- a/tests/session_basic2.phpt
+++ b/tests/session_basic2.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Session basic open, write, destroy
+--SKIPIF--
+<?php 
+if (!extension_loaded("memcached")) print "skip"; 
+if (!Memcached::HAVE_SESSION) print "skip";
+?>
+--INI--
+memcached.sess_locking = on
+memcached.sess_lock_wait = 150000
+memcached.sess_prefix = "memc.sess.key."
+session.save_handler = memcached
+
+--FILE--
+<?php
+include dirname (__FILE__) . '/config.inc';
+ini_set ('session.save_path', MEMC_SERVER_HOST . ':' . MEMC_SERVER_PORT);
+
+error_reporting(0);
+
+session_start(['lazy_write'=>TRUE);
+$_SESSION['foo'] = 1;
+session_write_close();
+
+$_SESSION = NULL;
+
+var_dump($_SESSION);
+session_start();
+var_dump($_SESSION);
+session_write_close();
+
+session_start();
+session_destroy();
+
+session_start();
+var_dump($_SESSION);
+session_write_close();
+
+
+--EXPECT--
+NULL
+array(1) {
+  ["foo"]=>
+  int(1)
+}
+array(0) {
+}

--- a/tests/session_basic3.phpt
+++ b/tests/session_basic3.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Session basic open, write, destroy
+--SKIPIF--
+<?php 
+if (!extension_loaded("memcached")) print "skip"; 
+if (!Memcached::HAVE_SESSION) print "skip";
+?>
+--INI--
+memcached.sess_locking = on
+memcached.sess_lock_wait = 150000
+memcached.sess_prefix = "memc.sess.key."
+session.save_handler = memcached
+
+--FILE--
+<?php
+include dirname (__FILE__) . '/config.inc';
+ini_set ('session.save_path', MEMC_SERVER_HOST . ':' . MEMC_SERVER_PORT);
+
+error_reporting(0);
+
+session_start(['read_only'=>TRUE);
+$_SESSION['foo'] = 1;
+session_write_close();
+
+$_SESSION = NULL;
+
+var_dump($_SESSION);
+session_start();
+var_dump($_SESSION);
+session_write_close();
+
+session_start();
+session_destroy();
+
+session_start();
+var_dump($_SESSION);
+session_write_close();
+
+
+--EXPECT--
+NULL
+array(1) {
+  ["foo"]=>
+  int(1)
+}
+array(0) {
+}


### PR DESCRIPTION
This patch adopts new session save handler definition that supports "lazy_write" which omit needless writes when session data is not changed. This save handler also supports "use_strict_mode" which prevents classic session adoption and never has session ID collisions.
