### PR TITLE
Extended key checking to match the language of the memcached spec

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -397,6 +397,21 @@ static int php_memc_list_entry(void)
 	return le_memc;
 }
 
+static int php_memc_valid_key(char *key)
+{
+  if (!*key) {
+    return 0;
+  }
+
+  for ( ; *key; ++key) {
+    if (iscntrl(*key) || isspace(*key)) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
 /* {{{ Memcached::__construct([string persistent_id[, callback on_new[, string connection_str]]]))
    Creates a Memcached object, optionally using persistent memcache connection */
 static PHP_METHOD(Memcached, __construct)
@@ -576,7 +591,7 @@ static void php_memc_get_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || !php_memc_valid_key(key)) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FROM_GET;
 	}
@@ -1448,7 +1463,7 @@ static void php_memc_store_impl(INTERNAL_FUNCTION_PARAMETERS, int op, zend_bool 
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || !php_memc_valid_key(key)) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1599,7 +1614,7 @@ static void php_memc_cas_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || !php_memc_valid_key(key)) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1717,7 +1732,7 @@ static void php_memc_delete_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || !php_memc_valid_key(key)) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1817,7 +1832,7 @@ static void php_memc_incdec_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key,
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || !php_memc_valid_key(key)) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -4482,6 +4497,7 @@ int php_memc_sess_list_entry(void)
 {
 	return le_memc_sess;
 }
+
 
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(memcached)

--- a/php_memcached_private.h
+++ b/php_memcached_private.h
@@ -29,6 +29,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <php.h>
 #include <php_main.h>
 
@@ -189,6 +190,7 @@ typedef struct {
 } memcached_sess;
 
 int php_memc_sess_list_entry(void);
+int php_memc_valid_key(char *);
 
 char *php_memc_printable_func (zend_fcall_info *fci, zend_fcall_info_cache *fci_cache TSRMLS_DC);
 

--- a/tests/keys.phpt
+++ b/tests/keys.phpt
@@ -18,12 +18,86 @@ var_dump ($binary->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 var_dump ($ascii->set ('ascii key with spaces', 'this is a test'));
 var_dump ($ascii->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 
+var_dump ($ascii->set ('', 'this is a test'));
+var_dump ($ascii->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
+
+for ($i=0;$i<32;$i++) {
+	var_dump ($ascii->set ('ascii key with non-printable char "' . chr($i) . '"newline', 'this is a test'));
+	var_dump ($ascii->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
+}
+
 var_dump ($ascii->set (str_repeat ('1234567890', 512), 'this is a test'));
 var_dump ($ascii->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 
 echo "OK" . PHP_EOL;
 
 --EXPECT--
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
 bool(false)
 bool(true)
 bool(false)


### PR DESCRIPTION
I ran across this [bug report](https://bugs.php.net/bug.php?id=69243). Memcached doesn't support keys containing whitespace or control characters, so it might be best to return a bad key result code rather than pass it on to the library. Dunno if this is the best approach, but it's a thought. :)
