### PR TITLE
Log cause when memcached error occurs

### DIFF
--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -72,7 +72,7 @@ static int php_memc_sess_lock(memcached_st *memc, const char *key TSRMLS_DC)
 				write_retry_attempts--;
 				continue;
 			}
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Write of lock failed");
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Memcached: Write of lock failed, last error was: %s", memcached_strerror(memc, status));
 			break;
 		}
 
@@ -322,6 +322,7 @@ PS_READ_FUNC(memcached)
 		free(payload);
 		return SUCCESS;
 	} else {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Memcached: Failed to read session data, last error was: %s", memcached_strerror(memc_sess->memc_sess, status));
 		return FAILURE;
 	}
 }
@@ -360,6 +361,7 @@ PS_WRITE_FUNC(memcached)
 		}
 	} while (write_try_attempts > 0);
 
+	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Memcached: Failed to write session data, last error was: %s", memcached_strerror(memc_sess->memc_sess, status));
 	return FAILURE;
 }
 


### PR DESCRIPTION
This PR adds more detailed error logging when a Memcached error occurs. 

While this doesn't always pinpoint the exact error cause (if there are retries used within libmemcached, it only provides the last error), it can help in understanding what's going on.

We've been using this patch in software we use and distribute, and it's been running just fine so far.
