### PR TITLE
Modified to use the emalloc instead of malloc.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -339,7 +339,7 @@ if test "$PHP_MEMCACHED" != "no"; then
       AC_MSG_RESULT([no])
     fi
 
-    PHP_MEMCACHED_FILES="php_memcached.c php_libmemcached_compat.c  g_fmt.c"
+    PHP_MEMCACHED_FILES="php_memcached.c php_libmemcached_compat.c  g_fmt.c php_zlib/zlib.c"
 
     if test "$PHP_SYSTEM_FASTLZ" != "no"; then
       AC_CHECK_HEADERS([fastlz.h], [ac_cv_have_fastlz="yes"], [ac_cv_have_fastlz="no"])
@@ -403,6 +403,7 @@ if test "$PHP_MEMCACHED" != "no"; then
     PHP_SUBST(MEMCACHED_SHARED_LIBADD)
 
     PHP_NEW_EXTENSION(memcached, $PHP_MEMCACHED_FILES, $ext_shared,,$SESSION_INCLUDES $IGBINARY_INCLUDES $LIBEVENT_INCLUDES $MSGPACK_INCLUDES)
+    PHP_ADD_BUILD_DIR($ext_builddir/php_zlib, 1)
     if test "ac_cv_have_fastlz" != "yes"; then
       PHP_ADD_BUILD_DIR($ext_builddir/fastlz, 1)
     fi

--- a/package.xml
+++ b/package.xml
@@ -58,6 +58,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <file role='src' name='g_fmt.h'/>
    <file role='src' name='fastlz/fastlz.c'/>
    <file role='src' name='fastlz/fastlz.h'/>
+   <file role='src' name='php_zlib/zlib.c'/>
+   <file role='src' name='php_zlib/zlib.h'/>
    <dir name="tests">
     <file role='test' name='001.phpt'/>
     <file role='test' name='version.phpt'/>

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -35,7 +35,7 @@
 #else
 #include "fastlz/fastlz.h"
 #endif
-#include <zlib.h>
+#include "php_zlib/zlib.h"
 
 #ifdef HAVE_JSON_API
 # include "ext/json/php_json.h"
@@ -3105,7 +3105,7 @@ char *s_compress_value (enum memcached_compression_type compression_type, const 
 			/* ZLIB returns the compressed size in this buffer */
 			compressed_size = buffer_size;
 
-			compress_status = (compress((Bytef *)buffer, &compressed_size, (Bytef *)payload, *payload_len) == Z_OK);
+			compress_status = (zlib_compress(buffer, &compressed_size, payload, *payload_len) == Z_OK);
 			MEMC_VAL_SET_FLAG(*flags, MEMC_VAL_COMPRESSION_ZLIB);
 			break;
 
@@ -3307,7 +3307,7 @@ char *s_decompress_value (const char *payload, size_t *payload_len, uint32_t fla
 		if (MEMC_VAL_HAS_FLAG(flags, MEMC_VAL_COMPRESSION_FASTLZ)) {
 			decompress_status = ((length = fastlz_decompress(payload, *payload_len, buffer, len)) > 0);
 		} else if (MEMC_VAL_HAS_FLAG(flags, MEMC_VAL_COMPRESSION_ZLIB)) {
-			decompress_status = (uncompress((Bytef *)buffer, &length, (Bytef *)payload, *payload_len) == Z_OK);
+			decompress_status = (zlib_uncompress(buffer, &length, payload, *payload_len) == Z_OK);
 		}
 	}
 

--- a/php_zlib/zlib.c
+++ b/php_zlib/zlib.c
@@ -1,0 +1,85 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2009-2010 The PHP Group                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is    |
+  | available through the world-wide-web at the following url:       |
+  | http://www.php.net/license/3_01.txt.                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to      |
+  | license@php.net so we can mail you a copy immediately.           |
+  +----------------------------------------------------------------------+
+*/
+
+#include "php.h"
+#include "zlib.h"
+
+/* This code is copy from "gzcompress" function. */
+static voidpf php_zlib_alloc(voidpf opaque, uInt items, uInt size)
+{
+    return (voidpf)safe_emalloc(items, size, 0);
+}
+
+/* This code is copy from "gzcompress" function. */
+static void php_zlib_free(voidpf opaque, voidpf address)
+{
+    efree((void*)address);
+}
+
+int zlib_compress_level(char *dest, size_t *destLen, const char *source, size_t sourceLen, int level)
+{
+    z_stream stream;
+    int err;
+
+    stream.next_in = (const Bytef *)source;
+    stream.avail_in = (uInt)sourceLen;
+    stream.next_out = dest;
+    stream.avail_out = (uInt)*destLen;
+    stream.zalloc = php_zlib_alloc;
+    stream.zfree = php_zlib_free;
+
+    if ((err = deflateInit(&stream, level)) != Z_OK) {
+        return err;
+    }
+
+    if ((err = deflate(&stream, Z_FINISH)) != Z_STREAM_END) {
+        deflateEnd(&stream);
+        return err == Z_OK ? Z_BUF_ERROR : err;
+    }
+    *destLen = stream.total_out;
+
+    err = deflateEnd(&stream);
+    return err;
+}
+
+int zlib_compress(char *dest, size_t *destLen, const char *source, size_t sourceLen)
+{
+    return zlib_compress_level(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
+}
+
+int zlib_uncompress(char *dest, size_t *destLen, const char *source, size_t sourceLen)
+{
+    z_stream stream;
+    int err;
+
+    stream.next_in = (const Bytef *)source;
+    stream.avail_in = (uInt)sourceLen;
+    stream.next_out = dest;
+    stream.avail_out = (uInt)*destLen;
+    stream.zalloc = (alloc_func)php_zlib_alloc;
+    stream.zfree = (free_func)php_zlib_free;
+
+    if ((err = inflateInit(&stream)) != Z_OK) {
+        return err;
+    }
+
+    if ((err = inflate(&stream, Z_FINISH)) != Z_STREAM_END) {
+        inflateEnd(&stream);
+        return err == Z_OK ? Z_BUF_ERROR : err;
+    }
+    *destLen = stream.total_out;
+
+    err = inflateEnd(&stream);
+    return err;
+}

--- a/php_zlib/zlib.h
+++ b/php_zlib/zlib.h
@@ -1,0 +1,21 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2009-2010 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+*/
+
+#include <zlib.h>
+
+int zlib_compress_level(char *dest, size_t *destLen, const char *source, size_t sourceLen, int level);
+
+int zlib_compress(char *dest, size_t *destLen, const char *source, size_t sourceLen);
+
+int zlib_uncompress(char *dest, size_t *destLen, const char *source, size_t sourceLen);


### PR DESCRIPTION
Zlib's "compress" function uses the "malloc" and "free" by default.
Therefore, it was modified to use the "emalloc" and "efree".