### PR TITLE
Two tests fail since these are not robust to customized settings in config.inc.local

### DIFF
--- a/tests/bug_18639.phpt
+++ b/tests/bug_18639.phpt
@@ -8,15 +8,13 @@ include dirname (__FILE__) . '/config.inc';
 $m = memc_get_instance ();
 
 var_dump($m->set('test', 'test1'));
-var_dump($m->getServerByKey('1'));
+$array = $m->getServerByKey('1');
+var_dump( $array["host"] == MEMC_SERVER_HOST ); 
+var_dump( $array["port"] == MEMC_SERVER_PORT ); 
+var_dump ( $array["weight"] ); 
 
 --EXPECTF--
 bool(true)
-array(3) {
-  ["host"]=>
-  string(9) "127.0.0.1"
-  ["port"]=>
-  int(11211)
-  ["weight"]=>
-  int(%r[01]%r)
-}
+bool(true)
+bool(true)
+int(%r[01]%r) 

--- a/tests/invoke_callback.phpt
+++ b/tests/invoke_callback.phpt
@@ -14,18 +14,12 @@ function my_func(Memcached $obj, $persistent_id = null)
 
 $m = new Memcached('hi', 'my_func');
 
-var_dump($m->getServerList());
-
+$serverList = $m->getServerList();
+var_dump( $serverList[0]["host"] == MEMC_SERVER_HOST ); 
+var_dump( $serverList[0]["port"] == MEMC_SERVER_PORT ); 
 echo "OK\n";
 
 --EXPECTF--
-array(1) {
-  [0]=>
-  array(2) {
-    ["host"]=>
-    string(9) "127.0.0.1"
-    ["port"]=>
-    int(11211)
-  }
-}
+bool(true)
+bool(true)
 OK


### PR DESCRIPTION
These two test now work with local configuration changes using config.inc.local (different server/port than localhost and 11211)

Kind regards,
Tobias Adolph
