### PR TITLE
remove ZEND_CTOR_MAKE_NULL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 php:
-    - 5.5
-    #- 5.4
-    #- 5.3
+    - 7.0
 env:
     - LIBMEMCACHED_VERSION=1.0.17
     - LIBMEMCACHED_VERSION=1.0.16

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -408,7 +408,6 @@ static PHP_METHOD(Memcached, __construct)
 	zend_fcall_info_cache fci_cache;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|S!f!S", &persistent_id, &fci, &fci_cache, &conn_str) == FAILURE) {
-		ZEND_CTOR_MAKE_NULL();
 		return;
 	}
 


### PR DESCRIPTION
ZEND_CTOR_MAKE_NULL was removed in https://github.com/php/php-src/pull/1205/files

Correct solution is to omit that call.

* Fixes issue in comments of #171.
* Fixes #173.

Also updated travis.yml for this branch. It's still failing due to igbinary not being ready for PHP7. The tracking issue for that is https://github.com/igbinary/igbinary/issues/40

We can either stop compiling and testing igbinary on the 7 branch, or leave it broken until they're ready for 7.