### PR TITLE
Adds a missed SASL presence constraint

### DIFF
--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -68,9 +68,11 @@ void s_destroy_mod_data(memcached_st *memc)
 {
 	php_memcached_user_data *user_data = memcached_get_user_data(memc);
 
+#if HAVE_MEMCACHED_SASL
 	if (user_data->has_sasl_data) {
 		memcached_destroy_sasl_auth_data(memc);
 	}
+#endif
 
 	memcached_free(memc);
 	pefree(memc, user_data->is_persistent);


### PR DESCRIPTION
This simply adds in the "usual" `#if HAVE_MEMCACHED_SASL` constraint around a call to `memcached_destroy_sasl_auth_data`. I think you simply overlooked this one with all the other changes.

Should also fix #217 - I only tested on Alpine Linux 3.3 though.