### PR TITLE
Document memcached.sess_binary_protocol

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -63,9 +63,11 @@ memcached.sess_remove_failed_servers = Off
 ; which could have old data or no data at all
 memcached.sess_number_of_replicas = 0
 
-; memcached session binary mode
-; libmemcached replicas only work if binary mode is enabled
-memcached.sess_binary = Off
+; Use the memcached binary protocol for memcached sessions (Instead of the text protocol)
+; libmemcached replicas work only if binary mode is enabled.
+; However, certain proxies (such as twemproxy) will work only if the binary protocol is disabled.
+; Default is On. In older versions of php-memcached, this setting was Off and was called memcached.sess_binary.
+memcached.sess_binary_protocol = On
 
 ; memcached session replica read randomize
 memcached.sess_randomize_replica_read = Off

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -19,7 +19,6 @@
 /* TODO
  * - set LIBKETAMA_COMPATIBLE as the default?
  * - fix unserialize(serialize($memc))
- * - ability to set binary protocol for sessions
  */
 
 #include "php_memcached.h"


### PR DESCRIPTION
And remove a TODO found in the code for allowing users to configure
whether or not to use binary protocols for sessions.

If there are any comments on formatting, what the comment for memcached.sess_binary_protocol should say, etc., I'll change my PR to address them.

For issue #233 
