### PR TITLE
[php7] Document ini settings for the default memcached connection configs

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -111,3 +111,32 @@ memcached.serializer = "igbinary"
 ; environment.
 ; the default is 2
 memcached.store_retry_count = 2
+
+; Sets the default for consistent hashing for new connections.
+; (To configure consistent hashing for session connections,
+; use memcached.sess_consistent_hash instead)
+;
+; If set to On, consistent hashing (libketama) is used
+; for session handling.
+; When consistent hashing is used, one can add or remove cache
+; node(s) without messing up too much with existing keys
+; default is Off
+memcached.default_consistent_hash = Off
+
+; Sets the default memcached protocol for new connections.
+; (To configure the memcached protocol for connections used by sessions,
+; use memcached.sess_binary_protocol instead)
+;
+; If set to On, the memcached binary protocol is used by default.
+; If set to Off, the memcached text protocol is used.
+; Default is Off
+memcached.default_binary_protocol = Off
+
+; Sets the default memcached connection timeout for new connections.
+; (To configure the memcached connection timeout for sessions,
+; use memcached.sess_connect_timeout instead)
+; In non-blocking mode this changes the value of the timeout.
+; during socket connection in milliseconds. Specifying -1 means an infinite timeout.
+; Specifying 0 means using the memcached library's default connection timeout.
+; Default is 0.
+memcached.default_connect_timeout = 0


### PR DESCRIPTION
This documents memcached.default_consistent_hash, default_binary_protocol, and
default_connect_timeout, for the php7 release

Any comments on wording/structure of comments? Is anything inaccurate/missing?

For issue #233