### PR TITLE
Document miscellaneous ini settings and new defaults for PHP7 release

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -12,11 +12,17 @@ memcached.sess_locking = On
 
 ; The minimum time, in milliseconds, to wait between session lock attempts.
 ; This value is double on each lock retry until memcached.sess_lock_wait_max
-; is reached
-memcached.sess_lock_wait_min = 0;
+; is reached, after which any further retries will take sess_lock_wait_max seconds.
+; Default is 1000.
+memcached.sess_lock_wait_min = 1000;
 
 ; The maximum time, in milliseconds, to wait between session lock attempts.
-memcached.sess_lock_wait_max = 0;
+; Default is 2000.
+memcached.sess_lock_wait_max = 2000;
+
+; The number of times to retry locking the session lock, not including the first attempt.
+; Default is 5.
+memcached.sess_lock_retries = 5;
 
 ; The time, in seconds, before a lock should release itself.
 ; Setting to 0 results in the default behaviour, which is to
@@ -29,16 +35,24 @@ memcached.sess_lock_expire = 0;
 ; the default value is "memc.sess.key."
 memcached.sess_prefix = "memc.sess.key."
 
+; Whether or not to re-use the memcached connections corresponding to the value(s)
+; of session.save_path after the execution of the script ends.
+; Don't use this if certain settings (e.g. SASL settings, sess_binary_protocol) would
+; be overridden between requests.
+; Default is Off.
+memcached.sess_persistent = Off
+
 ; memcached session consistent hash mode
 ; if set to On, consistent hashing (libketama) is used
 ; for session handling.
 ; When consistent hashing is used, one can add or remove cache
 ; node(s) without messing up too much with existing keys
-; default is Off
-memcached.sess_consistent_hash = Off
+; default is On
+memcached.sess_consistent_hash = On
 
-; Allow failed memcached server to automatically be removed 
-memcached.sess_remove_failed = 1
+; Allow failed memcached server to automatically be removed.
+; Default is Off. (In previous versions, this setting was called memcached.sess_remove_failed)
+memcached.sess_remove_failed_servers = Off
 
 ; Write data to a number of additional memcached servers
 ; This is "poor man's HA" as libmemcached calls it.
@@ -57,7 +71,7 @@ memcached.sess_binary = Off
 memcached.sess_randomize_replica_read = Off
 
 ; memcached connect timeout value
-; In non-blocking mode this changes the value of the timeout 
+; In non-blocking mode this changes the value of the timeout
 ; during socket connection in milliseconds. Specifying -1 means an infinite timeout.
 memcached.sess_connect_timeout = 1000
 


### PR DESCRIPTION
This updates some of the memcached.ini documentation settings
to reflect the default ini settings used in php_memcached.c.
Some new settings were added, and other settings had changes to their defaults.

There are other new/updated settings, which can be changed in other PRs.

I not completely certain of what memcached.server_failure_limit does and why it would be overriden, and http://docs.libmemcached.org/memcached_behavior.html#MEMCACHED_BEHAVIOR_REMOVE_FAILED_SERVERS says that  MEMCACHED_BEHAVIOR_SERVER_FAILURE_LIMIT was deprecated, so I'd prefer it if a contributor documented that setting outside of this PR.

For issue #233