### PR TITLE
Fix #243: Increment/decrement of an undefined key returns false with RES_SUCCESS

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -2248,11 +2248,11 @@ retry_inc_dec:
 		}
 	}
 
-	if (value == UINT64_MAX) {
+	if (s_memc_status_handle_result_code(intern, status) == FAILURE) {
 		RETURN_FALSE;
 	}
 
-	if (s_memc_status_handle_result_code(intern, status) == FAILURE) {
+	if (value == UINT64_MAX) {
 		RETURN_FALSE;
 	}
 

--- a/tests/incrdecr.phpt
+++ b/tests/incrdecr.phpt
@@ -10,8 +10,11 @@ $m = memc_get_instance ();
 echo "Not there\n";
 $m->delete('foo');
 var_dump($m->increment('foo', 1));
+var_dump($m->getResultCode());
 var_dump($m->decrement('foo', 1));
+var_dump($m->getResultCode());
 var_dump($m->get('foo'));
+var_dump($m->getResultCode());
 
 echo "Normal\n";
 $m->set('foo', 1);
@@ -37,8 +40,11 @@ var_dump($m->get('foo'));
 --EXPECT--
 Not there
 bool(false)
+int(16)
 bool(false)
+int(16)
 bool(false)
+int(16)
 Normal
 int(1)
 int(2)


### PR DESCRIPTION
Check the existence of an error, and only then if it is the maximum value.

Fix for #243