### PR TITLE
fix #250: non-null-terminated zend_string in s_decompress_value

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3443,6 +3443,8 @@ zend_string *s_decompress_value (const char *payload, size_t payload_len, uint32
 		decompress_status = (uncompress((Bytef *) buffer->val, &buffer->len, (Bytef *)payload, payload_len) == Z_OK);
 	}
 
+	ZSTR_VAL(buffer)[stored_length] = '\0';
+
 	if (!decompress_status) {
 		php_error_docref(NULL, E_WARNING, "could not decompress value");
 		zend_string_release (buffer);


### PR DESCRIPTION
a potential bug is introduced in https://github.com/php-memcached-dev/php-memcached/commit/dc5b22a8dace7373c1ef9d2946e89a660ed35b20#diff-f76062ebbcf30f0491af9ca937d17762R3270

the null-termination is missed during conversion; while zend_string_init did it correctly
https://github.com/php/php-src/blob/master/Zend/zend_string.h#L156

potential fix for #250 

-----
credit: thanks to my colleague @yuripave isolate the issue to the abovementioned commit. it makes further analysis much easier
