### PR TITLE
Fix object key validation

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -58,6 +58,11 @@
 #endif
 
 /****************************************
+  Protocol parameters
+****************************************/
+#define MEMC_OBJECT_KEY_MAX_LENGTH 250
+
+/****************************************
   Custom options
 ****************************************/
 #define MEMC_OPT_COMPRESSION        -1001
@@ -576,7 +581,7 @@ static void php_memc_get_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
+	if (key_len == 0 || key_len > MEMC_OBJECT_KEY_MAX_LENGTH || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FROM_GET;
 	}
@@ -1448,7 +1453,7 @@ static void php_memc_store_impl(INTERNAL_FUNCTION_PARAMETERS, int op, zend_bool 
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
+	if (key_len == 0 || key_len > MEMC_OBJECT_KEY_MAX_LENGTH || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1599,7 +1604,7 @@ static void php_memc_cas_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
+	if (key_len == 0 || key_len > MEMC_OBJECT_KEY_MAX_LENGTH || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1717,7 +1722,7 @@ static void php_memc_delete_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
+	if (key_len == 0 || key_len > MEMC_OBJECT_KEY_MAX_LENGTH || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1817,7 +1822,7 @@ static void php_memc_incdec_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key,
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
+	if (key_len == 0 || key_len > MEMC_OBJECT_KEY_MAX_LENGTH || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -576,7 +576,7 @@ static void php_memc_get_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FROM_GET;
 	}
@@ -1448,7 +1448,7 @@ static void php_memc_store_impl(INTERNAL_FUNCTION_PARAMETERS, int op, zend_bool 
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1599,7 +1599,7 @@ static void php_memc_cas_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1717,7 +1717,7 @@ static void php_memc_delete_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key)
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}
@@ -1817,7 +1817,7 @@ static void php_memc_incdec_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_key,
 	MEMC_METHOD_FETCH_OBJECT;
 	i_obj->rescode = MEMCACHED_SUCCESS;
 
-	if (key_len == 0 || strchr(key, ' ')) {
+	if (key_len == 0 || key_len > 250 || strchr(key, ' ') || strchr(key, '\n')) {
 		i_obj->rescode = MEMCACHED_BAD_KEY_PROVIDED;
 		RETURN_FALSE;
 	}

--- a/tests/keys.phpt
+++ b/tests/keys.phpt
@@ -15,7 +15,16 @@ $ascii = memc_get_instance ();
 var_dump ($binary->set ('binary key with spaces', 'this is a test'));
 var_dump ($binary->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 
+var_dump ($binary->set ('binarykeywith\nnewline', 'this is a test'));
+var_dump ($binary->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
+
 var_dump ($ascii->set ('ascii key with spaces', 'this is a test'));
+var_dump ($ascii->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
+
+var_dump ($binary->set ('asciikeywith\nnewline', 'this is a test'));
+var_dump ($binary->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
+
+var_dump ($ascii->set (''/*empty key*/, 'this is a test'));
 var_dump ($ascii->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 
 var_dump ($ascii->set (str_repeat ('1234567890', 512), 'this is a test'));
@@ -24,6 +33,12 @@ var_dump ($ascii->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 echo "OK" . PHP_EOL;
 
 --EXPECT--
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
 bool(false)
 bool(true)
 bool(false)

--- a/tests/keys.phpt
+++ b/tests/keys.phpt
@@ -15,13 +15,13 @@ $ascii = memc_get_instance ();
 var_dump ($binary->set ('binary key with spaces', 'this is a test'));
 var_dump ($binary->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 
-var_dump ($binary->set ('binarykeywith\nnewline', 'this is a test'));
+var_dump ($binary->set ('binarykeywithnewline' . PHP_EOL, 'this is a test'));
 var_dump ($binary->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 
 var_dump ($ascii->set ('ascii key with spaces', 'this is a test'));
 var_dump ($ascii->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 
-var_dump ($binary->set ('asciikeywith\nnewline', 'this is a test'));
+var_dump ($binary->set ('asciikeywithnewline' . PHP_EOL, 'this is a test'));
 var_dump ($binary->getResultCode () == Memcached::RES_BAD_KEY_PROVIDED);
 
 var_dump ($ascii->set (''/*empty key*/, 'this is a test'));


### PR DESCRIPTION
The current validation for the object keys is not complying with the [protocol specification](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L41) from memcached.

This PR aims at fixing this.