### PR TITLE
fix: compression edge case

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -868,6 +868,7 @@ zend_bool s_compress_value (php_memc_compression_type compression_type, zend_str
 
 	/* This means the value was too small to be compressed, still a success */
 	if (ZSTR_LEN(payload) < (compressed_size * MEMC_G(compression_factor))) {
+		MEMC_VAL_DEL_FLAG(*flags, MEMC_VAL_COMPRESSION_FASTLZ | MEMC_VAL_COMPRESSION_ZLIB);
 		efree (buffer);
 		return 1;
 	}

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -108,10 +108,10 @@ static int php_memc_list_entry(void) {
 #define MEMC_VAL_COMPRESSION_ZLIB    (1<<1)
 #define MEMC_VAL_COMPRESSION_FASTLZ  (1<<2)
 
-#define MEMC_VAL_GET_FLAGS(internal_flags)               ((internal_flags & MEMC_MASK_INTERNAL) >> 4)
-#define MEMC_VAL_SET_FLAG(internal_flags, internal_flag) ((internal_flags) |= ((internal_flag << 4) & MEMC_MASK_INTERNAL))
-#define MEMC_VAL_HAS_FLAG(internal_flags, internal_flag) ((MEMC_VAL_GET_FLAGS(internal_flags) & internal_flag) == internal_flag)
-#define MEMC_VAL_DEL_FLAG(internal_flags, internal_flag) internal_flags &= ~((internal_flag << 4) & MEMC_MASK_INTERNAL)
+#define MEMC_VAL_GET_FLAGS(internal_flags)               (((internal_flags) & MEMC_MASK_INTERNAL) >> 4)
+#define MEMC_VAL_SET_FLAG(internal_flags, internal_flag) ((internal_flags) |= (((internal_flag) << 4) & MEMC_MASK_INTERNAL))
+#define MEMC_VAL_HAS_FLAG(internal_flags, internal_flag) ((MEMC_VAL_GET_FLAGS(internal_flags) & (internal_flag)) == (internal_flag))
+#define MEMC_VAL_DEL_FLAG(internal_flags, internal_flag) (internal_flags &= (~(((internal_flag) << 4) & MEMC_MASK_INTERNAL)))
 
 /****************************************
   User-defined flags
@@ -867,7 +867,7 @@ zend_bool s_compress_value (php_memc_compression_type compression_type, zend_str
 	}
 
 	/* This means the value was too small to be compressed, still a success */
-	if (compressed_size > (ZSTR_LEN(payload) * MEMC_G(compression_factor))) {
+	if (ZSTR_LEN(payload) < (compressed_size * MEMC_G(compression_factor))) {
 		efree (buffer);
 		return 1;
 	}

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -867,7 +867,7 @@ zend_bool s_compress_value (php_memc_compression_type compression_type, zend_str
 	}
 
 	/* This means the value was too small to be compressed, still a success */
-	if (ZSTR_LEN(payload) < (compressed_size * MEMC_G(compression_factor))) {
+	if (ZSTR_LEN(payload) <= (compressed_size * MEMC_G(compression_factor))) {
 		MEMC_VAL_DEL_FLAG(*flags, MEMC_VAL_COMPRESSION_FASTLZ | MEMC_VAL_COMPRESSION_ZLIB);
 		efree (buffer);
 		return 1;


### PR DESCRIPTION
the condition to do compression is incorrent since previous refactoring. according to docs

https://secure.php.net/manual/en/memcached.configuration.php#ini.memcached.compression-factor
> Store **compressed** if: plain_len > comp_len * factor

https://github.com/php-memcached-dev/php-memcached/blob/master/memcached.ini#L93
> store **compressed** if: plain_len > comp_len * factor

hence, the condition (to early exit, without compression) should be
`if (ZSTR_LEN(payload) < (compressed_size * compression_factor))`

------

PR includes
- fix to the compression_factor formula (whether to compress or not),
- correctly unset MEMC_VAL_COMPRESSION_{FASTLZ,ZLIB} flags flags properly when plain-text is sent
