### PR TITLE
0 max_execution_time ini value

### DIFF
--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -113,7 +113,7 @@ time_t s_lock_expiration()
 		return s_adjust_expiration(MEMC_SESS_INI(lock_expiration));
 	}
 	else {
-		zend_long max_execution_time = zend_ini_long(ZEND_STRS("max_execution_time"), 0);
+		zend_long max_execution_time = zend_ini_long(ZEND_STRL("max_execution_time"), 0);
 		if (max_execution_time > 0) {
 			return s_adjust_expiration(max_execution_time);
 		}


### PR DESCRIPTION
It seems that zend_ini_long doesn't work anymore with ZEND_STRS
and that the extension should use ZEND_STRL, back again.

We inspected and stumbled upon this issue when some session had their lock stuck. It seems that the extension was unable to retrieve the INI value for max_execution_time.
This was at some point changed to ZEND_STRS - but it seems that now it has to use ZEND_STRL.

Anyone can probably easily test this and confirm that it is indeed an issue and that this fixes it.
