### PR TITLE
Cherry pick test workaround for very old libmemcached from php7 branch

### DIFF
--- a/tests/config.inc
+++ b/tests/config.inc
@@ -64,3 +64,8 @@ function memc_create_combinations ($name, $serializer, $ignore_object_type = fal
 			),
 	);
 }
+
+function memc_get_version($memc, $host = '') {
+	$version = $memc->getVersion();
+	return array_pop($version);
+}

--- a/tests/expire.phpt
+++ b/tests/expire.phpt
@@ -3,7 +3,9 @@ Memcached store, fetch & touch expired key
 --XFAIL--
 https://code.google.com/p/memcached/issues/detail?id=275
 --SKIPIF--
-<?php if (!extension_loaded("memcached")) print "skip";
+<?php
+$min_version = "1.4.8";
+include dirname(__FILE__) . "/skipif.inc";
 if (!method_exists("memcached", "touch")) die ("skip memcached::touch is not available");
 ?>
 --FILE--

--- a/tests/gh_155.phpt
+++ b/tests/gh_155.phpt
@@ -1,7 +1,6 @@
 --TEST--
 Test for bug 155
 --SKIPIF--
-<<<<<<< HEAD
 <?php
 $min_version = "1.4.8";
 include dirname(__FILE__) . "/skipif.inc";

--- a/tests/gh_155.phpt
+++ b/tests/gh_155.phpt
@@ -1,7 +1,12 @@
 --TEST--
 Test for bug 155
 --SKIPIF--
-<?php if (!extension_loaded("memcached")) print "skip"; ?>
+<<<<<<< HEAD
+<?php
+$min_version = "1.4.8";
+include dirname(__FILE__) . "/skipif.inc";
+if (Memcached::LIBMEMCACHED_VERSION_HEX < 0x01000016) die ('skip too old libmemcached');
+?>
 --FILE--
 <?php
 include dirname (__FILE__) . '/config.inc';

--- a/tests/gh_77.phpt
+++ b/tests/gh_77.phpt
@@ -1,8 +1,10 @@
 --TEST--
 Test for Github issue #77
 --SKIPIF--
-<?php if (!extension_loaded("memcached")) print "skip";
-      if (Memcached::LIBMEMCACHED_VERSION_HEX < 0x01000016) die ('skip too old libmemcached');
+<?php
+$min_version = "1.4.8";
+include dirname(__FILE__) . "/skipif.inc";
+if (Memcached::LIBMEMCACHED_VERSION_HEX < 0x01000016) die ('skip too old libmemcached');
 ?>
 --FILE--
 <?php

--- a/tests/skipif.inc
+++ b/tests/skipif.inc
@@ -1,0 +1,16 @@
+<?php
+if (!extension_loaded("memcached")) {
+	die("skip memcached is not loaded\n");
+}
+
+include dirname(__FILE__) . "/config.inc";
+
+if (($m = memc_get_instance()) === NULL) {
+	die ("skip can not connect to server\n");
+}
+
+if (isset($min_version)) {
+	if (version_compare(memc_get_version($m), $min_version, "<")) {
+		die("skip version of server pool is too old, $min_version is required\n");
+	}
+}

--- a/tests/touch_binary.phpt
+++ b/tests/touch_binary.phpt
@@ -1,8 +1,10 @@
 --TEST--
 Touch in binary mode
 --SKIPIF--
-<?php if (!extension_loaded("memcached")) print "skip";
-	  if (Memcached::LIBMEMCACHED_VERSION_HEX < 0x01000016) die ('skip too old libmemcached');
+<?php
+$min_version = "1.4.8"; //TOUCH is added since 1.4.8
+include dirname(__FILE__) . "/skipif.inc";
+if (Memcached::LIBMEMCACHED_VERSION_HEX < 0x01000016) die ('skip too old libmemcached');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
According to memcached wiki, touch is added since 1.4.8 
https://github.com/memcached/memcached/wiki/ReleaseNotes148
