### PR TITLE
Igbinary php7 development is in igbinary/igbinary master branch now

### DIFF
--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -67,8 +67,8 @@ function install_libmemcached() {
 }
 
 function install_igbinary() {
-    git clone https://github.com/igbinary/igbinary7.git
-    pushd igbinary7
+    git clone https://github.com/igbinary/igbinary.git
+    pushd igbinary
         phpize
         ./configure
         make


### PR DESCRIPTION
igbinary7 was moved to src/php7 of igbinary, and bug fixes/improvements were/will be added there later.

See https://github.com/igbinary/igbinary/pull/62