### PR TITLE
getMulti: check status on poll timeout

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -135,6 +135,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     <file role='test' name='sasl_basic.phpt'/>
     <file role='test' name='getserverbykey.phpt'/>
     <file role='test' name='gh_155.phpt'/>
+    <file role='test' name='getmulti_poll_timeout.phpt'/>
   </dir>
  </dir>
  </contents>

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -870,6 +870,11 @@ static void php_memc_getMulti_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_ke
 		}
 	}
 
+	if (i_obj->rescode == MEMCACHED_SUCCESS && status != MEMCACHED_SUCCESS && status != MEMCACHED_END) {
+		status = MEMCACHED_SOME_ERRORS;
+		php_memc_handle_error(i_obj, status TSRMLS_CC);
+	}
+
 	memcached_result_free(&result);
 
 	if (EG(exception)) {

--- a/tests/getmulti_poll_timeout.phpt
+++ b/tests/getmulti_poll_timeout.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Memcached::getMulti() poll timeout
+--SKIPIF--
+<?php if (!extension_loaded("memcached")) print "skip"; ?>
+--FILE--
+<?php
+include dirname (__FILE__) . '/config.inc';
+$m = memc_get_instance(array(Memcached::OPT_POLL_TIMEOUT => 1));
+
+var_dump($m->getOption(Memcached::OPT_POLL_TIMEOUT));
+
+$keys = array();
+for ($i = 0; $i < 100000; $i++) {
+	$keys[] = $i;
+	$m->set($i, $i, 3600);
+}
+
+$v = $m->getMulti($keys);
+
+var_dump($m->getResultCode() != Memcached::RES_SUCCESS);
+
+--EXPECT--
+int(1)
+bool(true)


### PR DESCRIPTION
Add status check to getMulti() and update error accordingly for the case when poll timeout
(OPT_POLL_TIMEOUT) was reached.

On poll timeout error is not updated, i.e. it's usually SUCCESS with empty response. You can reproduce the issue with code like this (you might have to increase $keys_count in your environment):

```
<?php

$m = new Memcached();
$m->addServer('127.0.0.1', 11211);
$m->setOption(Memcached::OPT_POLL_TIMEOUT, 10);

$keys_count = 100000;
$keys = array();

for ($x = 1; $x <= $keys_count; $x++) {
    $keys[] = $x;
    $m->set($x, $x, 0);
}

$r = $m->getMulti($keys);
echo("err=" . var_export($m->getResultCode(), true)
     . " err_msg=" . var_export($m->getResultMessage(), true)
     . " cnt=" . count($r) . "\n");

```

- unpatched output: `err=0 err_msg='SUCCESS' cnt=0`
- patched output: `err=19 err_msg='SOME ERRORS WERE REPORTED' cnt=0`
