### PR TITLE
Fix tests for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ php:
 
 matrix:
     fast_finish: true
-    allow_failures:
-        - php: 7.1
 
 env:
     - LIBMEMCACHED_VERSION=1.0.18 # Debian Jessie / Ubuntu Xenial
@@ -32,5 +30,3 @@ script:
 cache:
     directories: 
     - $HOME/cache
-
-    

--- a/package.xml
+++ b/package.xml
@@ -165,6 +165,7 @@ Tests
     <file role='test' name='stats.phpt'/>
     <file role='test' name='default_behavior.phpt'/>
     <file role='test' name='reset_keyprefix.phpt'/>
+    <file role='test' name='session_lock-php71.phpt'/>
   </dir>
  </dir>
  </contents>

--- a/tests/invoke_callback_2.phpt
+++ b/tests/invoke_callback_2.phpt
@@ -18,9 +18,9 @@ function init_cb_fail($m, $id) {
 	echo "configured, should not be called.\n";
 }
 
-function init_cb_arg($m, $id, $arg) {
+function init_cb_arg($m, $id) {
+    var_dump(func_num_args());
 	var_dump($id);
-	var_dump($arg);
 }
 
 function init_nopersist_cb($m, $id) {
@@ -33,14 +33,13 @@ class Foo extends Memcached {
 		parent::__construct($id, array($this, 'init'));
 	}
 
-	function init($obj, $id, $options) {
+	function init($obj, $id) {
+	    var_dump(func_num_args());
 		var_dump($this->isPristine());
 		var_dump($this->isPersistent());
 		var_dump($id);
 	}
 }
-
-error_reporting(0);
 
 echo "cb call\n";
 $m1 = new Memcached('foo1', 'init_cb');
@@ -50,7 +49,6 @@ $m1 = new Memcached('foo1', 'init_cb_fail');
 
 echo "cb arg without arg\n";
 $m1 = new Memcached('foo3', 'init_cb_arg');
-echo $php_errormsg, "\n";
 
 echo "cb arg not persistent\n";
 $m1 = new Memcached(null, 'init_nopersist_cb');
@@ -63,7 +61,7 @@ $m1 = new Foo('baz');
 
 echo "cb second persistent in object\n";
 $m1 = new Foo('baz');
-
+?>
 --EXPECT--
 cb call
 string(9) "Memcached"
@@ -71,17 +69,18 @@ bool(true)
 string(4) "foo1"
 cb not run
 cb arg without arg
+int(2)
 string(4) "foo3"
-NULL
-
 cb arg not persistent
 bool(false)
 NULL
 cb in object
+int(2)
 bool(true)
 bool(false)
 NULL
 cb persistent in object
+int(2)
 bool(true)
 bool(true)
 string(3) "baz"

--- a/tests/invoke_callback_2.phpt
+++ b/tests/invoke_callback_2.phpt
@@ -19,7 +19,7 @@ function init_cb_fail($m, $id) {
 }
 
 function init_cb_arg($m, $id) {
-    var_dump(func_num_args());
+	var_dump(func_num_args());
 	var_dump($id);
 }
 
@@ -34,7 +34,7 @@ class Foo extends Memcached {
 	}
 
 	function init($obj, $id) {
-	    var_dump(func_num_args());
+		var_dump(func_num_args());
 		var_dump($this->isPristine());
 		var_dump($this->isPersistent());
 		var_dump($id);

--- a/tests/session_lock-php71.phpt
+++ b/tests/session_lock-php71.phpt
@@ -5,7 +5,7 @@ Session lock
 include dirname(__FILE__) . "/skipif.inc"; 
 if (!Memcached::HAVE_SESSION) print "skip";
 
-if (PHP_VERSION_ID >= 70100) print "skip";
+if (PHP_VERSION_ID < 70100) print "skip";
 ?>
 --INI--
 memcached.sess_locking       = true
@@ -57,4 +57,6 @@ string(1) "1"
 bool(false)
 
 Warning: session_start(): Unable to clear session lock record in %s on line %d
+
+Warning: session_start(): Failed to read session data: memcached (path: 127.0.0.1:11211) in /mnt/serve-a-lot_arjen/checkouts/php-memcached/tests/session_lock-php71.php on line 27
 OK

--- a/tests/session_lock-php71.phpt
+++ b/tests/session_lock-php71.phpt
@@ -58,5 +58,5 @@ bool(false)
 
 Warning: session_start(): Unable to clear session lock record in %s on line %d
 
-Warning: session_start(): Failed to read session data: memcached (path: 127.0.0.1:11211) in /mnt/serve-a-lot_arjen/checkouts/php-memcached/tests/session_lock-php71.php on line 27
+Warning: session_start(): Failed to read session data: memcached (path: 127.0.0.1:11211) in %s on line %d
 OK


### PR DESCRIPTION
invoke_callback_2 fails because of ArgumentCountException (init_cb_arg gets only 2 args).
Check number of passed arguments with func_num_args() insteadof checking $args is null

session_lock fails because of second warning in 7.1
Skip session_lock.phpt for php < 7.1 and create new testcase for >= 7.1 which tests both warnings.