### PR TITLE
re-add 64bits tests (skipped on 32bits)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -74,6 +74,7 @@ Fixes
    <file role='src' name='fastlz/fastlz.c'/>
    <file role='src' name='fastlz/fastlz.h'/>
    <dir name="tests">
+    <file role='test' name='skipif.inc'/>
     <file role='test' name='001.phpt'/>
     <file role='test' name='version.phpt'/>
     <file role='test' name='bug_16084.phpt'/>
@@ -143,9 +144,11 @@ Fixes
     <file role='test' name='setmulti.phpt'/>
     <file role='test' name='cachecallback.phpt'/>
     <file role='test' name='incrdecr.phpt'/>
+    <file role='test' name='incrdecr_64.phpt'/>
     <file role='test' name='incrdecr_initial.phpt'/>
     <file role='test' name='incrdecr_invalid_key.phpt'/>
     <file role='test' name='incrdecr_bykey.phpt'/>
+    <file role='test' name='incrdecr_bykey_64.phpt'/>
     <file role='test' name='invalid_options.phpt'/>
     <file role='test' name='keys.phpt'/>
     <file role='test' name='testdata.res'/>

--- a/tests/incrdecr_64.phpt
+++ b/tests/incrdecr_64.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Memcached::increment() Memcached::decrement() on 64bits
+--SKIPIF--
+<?php
+include "skipif.inc";
+if (PHP_INT_SIZE < 8) die("skip valid for 64-bit only");
+?>
+--FILE--
+<?php
+include dirname (__FILE__) . '/config.inc';
+$m = memc_get_instance ();
+
+echo "Not there\n";
+$m->delete('foo');
+var_dump($m->increment('foo', 1));
+var_dump($m->getResultCode());
+var_dump($m->decrement('foo', 1));
+var_dump($m->getResultCode());
+var_dump($m->get('foo'));
+var_dump($m->getResultCode());
+
+echo "Normal\n";
+$m->set('foo', 1);
+var_dump($m->get('foo'));
+$m->increment('foo');
+var_dump($m->get('foo'));
+$m->increment('foo', 2);
+var_dump($m->get('foo'));
+$m->decrement('foo');
+var_dump($m->get('foo'));
+$m->decrement('foo', 2);
+var_dump($m->get('foo'));
+
+error_reporting(0);
+
+echo "Negative offset\n";
+$php_errormsg = '';
+$m->increment('foo', -1);
+echo $php_errormsg, "\n";
+var_dump($m->get('foo'));
+
+$php_errormsg = '';
+$m->decrement('foo', -1);
+echo $php_errormsg, "\n";
+var_dump($m->get('foo'));
+
+echo "Enormous offset\n";
+$m->increment('foo', 4294967296);
+var_dump($m->get('foo'));
+
+$m->decrement('foo', 4294967296);
+var_dump($m->get('foo'));
+
+--EXPECT--
+Not there
+bool(false)
+int(16)
+bool(false)
+int(16)
+bool(false)
+int(16)
+Normal
+int(1)
+int(2)
+int(4)
+int(3)
+int(1)
+Negative offset
+Memcached::increment(): offset cannot be a negative value
+int(1)
+Memcached::decrement(): offset cannot be a negative value
+int(1)
+Enormous offset
+int(4294967297)
+int(1)

--- a/tests/incrdecr_bykey_64.phpt
+++ b/tests/incrdecr_bykey_64.phpt
@@ -1,0 +1,69 @@
+--TEST--
+Memcached::incrementByKey() Memcached::decrementByKey() on 64bits
+--SKIPIF--
+<?php
+include "skipif.inc";
+if (PHP_INT_SIZE < 8) die("skip valid for 64-bit only");
+?>
+--FILE--
+<?php
+include dirname (__FILE__) . '/config.inc';
+$m = memc_get_instance ();
+
+echo "Not there\n";
+$m->delete('foo');
+var_dump($m->incrementByKey('foo', 'foo', 1));
+var_dump($m->decrementByKey('foo', 'foo', 1));
+var_dump($m->get('foo'));
+
+echo "Normal\n";
+$m->set('foo', 1);
+var_dump($m->get('foo'));
+$m->incrementByKey('foo', 'foo');
+var_dump($m->get('foo'));
+$m->incrementByKey('foo', 'foo', 2);
+var_dump($m->get('foo'));
+$m->decrementByKey('foo', 'foo');
+var_dump($m->get('foo'));
+$m->decrementByKey('foo', 'foo', 2);
+var_dump($m->get('foo'));
+
+error_reporting(0);
+
+echo "Negative offset\n";
+$php_errormsg = '';
+$m->incrementByKey('foo', 'foo', -1);
+echo $php_errormsg, "\n";
+var_dump($m->get('foo'));
+
+$php_errormsg = '';
+$m->decrementByKey('foo', 'foo', -1);
+echo $php_errormsg, "\n";
+var_dump($m->get('foo'));
+
+echo "Enormous offset\n";
+$m->incrementByKey('foo', 'foo', 4294967296);
+var_dump($m->get('foo'));
+
+$m->decrementByKey('foo', 'foo', 4294967296);
+var_dump($m->get('foo'));
+
+--EXPECT--
+Not there
+bool(false)
+bool(false)
+bool(false)
+Normal
+int(1)
+int(2)
+int(4)
+int(3)
+int(1)
+Negative offset
+Memcached::incrementByKey(): offset cannot be a negative value
+int(1)
+Memcached::decrementByKey(): offset cannot be a negative value
+int(1)
+Enormous offset
+int(4294967297)
+int(1)


### PR DESCRIPTION
I also add the skipif.inc which was obviously missing in the archvie.