### PR TITLE
Refresh memcached.ini and set sess_binary_protocol off by default with older libmemcached

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -64,7 +64,9 @@
 ; Use the memcached binary protocol for memcached sessions (Instead of the text protocol)
 ; libmemcached replicas work only if binary mode is enabled.
 ; However, certain proxies (such as twemproxy) will work only if the binary protocol is disabled.
-; Default is On. In older versions of php-memcached, this setting was Off and was called memcached.sess_binary.
+; In older versions of php-memcached, this setting was Off and was called memcached.sess_binary.
+; Default is On with libmemcached 1.0.18 or newer.
+; Default is Off with older version.
 ;memcached.sess_binary_protocol = On
 
 ; memcached session replica read randomize

--- a/memcached.ini
+++ b/memcached.ini
@@ -2,45 +2,39 @@
 ; Use session locking
 ; valid values: On, Off
 ; the default is On
-memcached.sess_locking = On
-
-; !! DEPRECATED AND REMOVED in 3.x !!
-; memcached.sess_lock_wait = 150000
-
-; !! DEPRECATED AND REMOVED in 3.x !!
-; memcached.sess_lock_max_wait = 0;
+;memcached.sess_locking = On
 
 ; The minimum time, in milliseconds, to wait between session lock attempts.
 ; This value is double on each lock retry until memcached.sess_lock_wait_max
 ; is reached, after which any further retries will take sess_lock_wait_max seconds.
 ; Default is 1000.
-memcached.sess_lock_wait_min = 1000;
+;memcached.sess_lock_wait_min = 1000;
 
 ; The maximum time, in milliseconds, to wait between session lock attempts.
 ; Default is 2000.
-memcached.sess_lock_wait_max = 2000;
+;memcached.sess_lock_wait_max = 2000;
 
 ; The number of times to retry locking the session lock, not including the first attempt.
 ; Default is 5.
-memcached.sess_lock_retries = 5;
+;memcached.sess_lock_retries = 5;
 
 ; The time, in seconds, before a lock should release itself.
 ; Setting to 0 results in the default behaviour, which is to
 ; use the memcached.sess_lock_max_wait setting. If that is
 ; also 0, max_execution_time will be used.
-memcached.sess_lock_expire = 0;
+;memcached.sess_lock_expire = 0;
 
 ; memcached session key prefix
 ; valid values are strings less than 219 bytes long
 ; the default value is "memc.sess.key."
-memcached.sess_prefix = "memc.sess.key."
+;memcached.sess_prefix = "memc.sess.key."
 
 ; Whether or not to re-use the memcached connections corresponding to the value(s)
 ; of session.save_path after the execution of the script ends.
 ; Don't use this if certain settings (e.g. SASL settings, sess_binary_protocol) would
 ; be overridden between requests.
 ; Default is Off.
-memcached.sess_persistent = Off
+;memcached.sess_persistent = Off
 
 ; memcached session consistent hash mode
 ; if set to On, consistent hashing (libketama) is used
@@ -48,11 +42,15 @@ memcached.sess_persistent = Off
 ; When consistent hashing is used, one can add or remove cache
 ; node(s) without messing up too much with existing keys
 ; default is On
-memcached.sess_consistent_hash = On
+;memcached.sess_consistent_hash = On
 
 ; Allow failed memcached server to automatically be removed.
 ; Default is Off. (In previous versions, this setting was called memcached.sess_remove_failed)
-memcached.sess_remove_failed_servers = Off
+;memcached.sess_remove_failed_servers = Off
+
+; Set this value to enable the server be removed after
+; configured number of continuous times connection failure.
+;memcached.sess_server_failure_limit = 0
 
 ; Write data to a number of additional memcached servers
 ; This is "poor man's HA" as libmemcached calls it.
@@ -61,34 +59,34 @@ memcached.sess_remove_failed_servers = Off
 ; from a replica. However, if the failed memcache server
 ; becomes available again it will read the session from there
 ; which could have old data or no data at all
-memcached.sess_number_of_replicas = 0
+;memcached.sess_number_of_replicas = 0
 
 ; Use the memcached binary protocol for memcached sessions (Instead of the text protocol)
 ; libmemcached replicas work only if binary mode is enabled.
 ; However, certain proxies (such as twemproxy) will work only if the binary protocol is disabled.
 ; Default is On. In older versions of php-memcached, this setting was Off and was called memcached.sess_binary.
-memcached.sess_binary_protocol = On
+;memcached.sess_binary_protocol = On
 
 ; memcached session replica read randomize
-memcached.sess_randomize_replica_read = Off
+;memcached.sess_randomize_replica_read = Off
 
 ; memcached connect timeout value
 ; In non-blocking mode this changes the value of the timeout
 ; during socket connection in milliseconds. Specifying -1 means an infinite timeout.
-memcached.sess_connect_timeout = 1000
+;memcached.sess_connect_timeout = 1000
 
 ; Session SASL username
 ; Both username and password need to be set for SASL to be enabled
 ; In addition to this memcached.use_sasl needs to be on
-memcached.sess_sasl_username = NULL
+;memcached.sess_sasl_username = NULL
 
 ; Session SASL password
-memcached.sess_sasl_password = NULL
+;memcached.sess_sasl_password = NULL
 
 ; Set the compression type
 ; valid values are: fastlz, zlib
 ; the default is fastlz
-memcached.compression_type = "fastlz"
+;memcached.compression_type = "fastlz"
 
 ; Compression factor
 ; Store compressed value only if the compression
@@ -98,13 +96,13 @@ memcached.compression_type = "fastlz"
 ;    plain_len > comp_len * factor
 ;
 ; the default value is 1.3 (23% space saving)
-memcached.compression_factor = "1.3"
+;memcached.compression_factor = "1.3"
 
 ; The compression threshold
 ;
 ; Do not compress serialized values below this threshold.
 ; the default is 2000 bytes
-memcached.compression_threshold = 2000
+;memcached.compression_threshold = 2000
 
 ; Set the default serializer for new memcached objects.
 ; valid values are: php, igbinary, json, json_array, msgpack
@@ -119,14 +117,14 @@ memcached.compression_threshold = 2000
 ; msgpack - a cross-language binary serializer
 ;
 ; The default is igbinary if available, then msgpack if available, then php otherwise.
-memcached.serializer = "igbinary"
+;memcached.serializer = "igbinary"
 
 ; The amount of retries for failed store commands.
 ; This mechanism allows transparent fail-over to secondary servers when
 ; set/increment/decrement/setMulti operations fail on the desired server in a multi-server
 ; environment.
 ; the default is 2
-memcached.store_retry_count = 2
+;memcached.store_retry_count = 2
 
 ; Sets the default for consistent hashing for new connections.
 ; (To configure consistent hashing for session connections,
@@ -137,7 +135,7 @@ memcached.store_retry_count = 2
 ; When consistent hashing is used, one can add or remove cache
 ; node(s) without messing up too much with existing keys
 ; default is Off
-memcached.default_consistent_hash = Off
+;memcached.default_consistent_hash = Off
 
 ; Sets the default memcached protocol for new connections.
 ; (To configure the memcached protocol for connections used by sessions,
@@ -146,7 +144,7 @@ memcached.default_consistent_hash = Off
 ; If set to On, the memcached binary protocol is used by default.
 ; If set to Off, the memcached text protocol is used.
 ; Default is Off
-memcached.default_binary_protocol = Off
+;memcached.default_binary_protocol = Off
 
 ; Sets the default memcached connection timeout for new connections.
 ; (To configure the memcached connection timeout for sessions,
@@ -155,4 +153,4 @@ memcached.default_binary_protocol = Off
 ; during socket connection in milliseconds. Specifying -1 means an infinite timeout.
 ; Specifying 0 means using the memcached library's default connection timeout.
 ; Default is 0.
-memcached.default_connect_timeout = 0
+;memcached.default_connect_timeout = 0

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -332,7 +332,11 @@ PHP_INI_BEGIN()
 	MEMC_SESSION_INI_ENTRY("lock_wait_max",          "2000",       OnUpdateLongGEZero,     lock_wait_max)
 	MEMC_SESSION_INI_ENTRY("lock_retries",           "5",          OnUpdateLong,           lock_retries)
 	MEMC_SESSION_INI_ENTRY("lock_expire",            "0",          OnUpdateLongGEZero,     lock_expiration)
+#if defined(LIBMEMCACHED_VERSION_HEX) && LIBMEMCACHED_VERSION_HEX < 0x01000018
+	MEMC_SESSION_INI_ENTRY("binary_protocol",        "0",          OnUpdateBool,           binary_protocol_enabled)
+#else
 	MEMC_SESSION_INI_ENTRY("binary_protocol",        "1",          OnUpdateBool,           binary_protocol_enabled)
+#endif
 	MEMC_SESSION_INI_ENTRY("consistent_hash",        "1",          OnUpdateBool,           consistent_hash_enabled)
 	MEMC_SESSION_INI_ENTRY("number_of_replicas",     "0",          OnUpdateLongGEZero,     number_of_replicas)
 	MEMC_SESSION_INI_ENTRY("randomize_replica_read", "0",          OnUpdateLongGEZero,     randomize_replica_read_enabled)


### PR DESCRIPTION
1st commit is mostly cleanup, follow php practice, but needed by the second one

2nd commit is another way to (try to) improve user experience with older libmemcached version and avoid the warning about using touch (which can be confusing) => for discussion.