### PR TITLE
Fix optional parameter getStats($type)

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3877,7 +3877,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_addServer, 0, 0, 2)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_getStats, 0, 0, 0)
-	ZEND_ARG_INFO(0, args)
+	ZEND_ARG_INFO(0, type)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_addServers, 0)

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3876,6 +3876,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_addServer, 0, 0, 2)
 	ZEND_ARG_INFO(0, weight)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_getStats, 0, 0, 0)
+	ZEND_ARG_INFO(0, args)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_addServers, 0)
 	ZEND_ARG_ARRAY_INFO(0, servers, 0)
 ZEND_END_ARG_INFO()
@@ -3932,10 +3936,6 @@ ZEND_BEGIN_ARG_INFO(arginfo_setBucket, 3)
 	ZEND_ARG_INFO(0, host_map)
 	ZEND_ARG_INFO(0, forward_map)
 	ZEND_ARG_INFO(0, replicas)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO(arginfo_getStats, 0)
-	ZEND_ARG_INFO(0, args)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_getVersion, 0)


### PR DESCRIPTION
[type](https://github.com/php-memcached-dev/php-memcached/pull/298) is optional, but `ReflectionParameter::isOptional()` returns `false`.

### example

```php
        $method = new \ReflectionMethod(new \Memcached(), 'getStats');
        foreach ($method->getParameters() as $p) {
            var_dump($p->name, $p->isOptional());
        }
```

### before

```
string(4) "args"
bool(false)
```

### after

```
string(4) "type"
bool(true)
```