### PR TITLE
Remove unused defines

### DIFF
--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -22,9 +22,6 @@
 
 extern ZEND_DECLARE_MODULE_GLOBALS(php_memcached)
 
-#define MEMC_SESS_DEFAULT_LOCK_WAIT 150000
-#define MEMC_SESS_LOCK_EXPIRATION 30
-
 #define REALTIME_MAXDELTA 60*60*24*30
 
 ps_module ps_mod_memcached = {


### PR DESCRIPTION
The defines MEMC_SESS_DEFAULT_LOCK_WAIT and MEMC_SESS_LOCK_EXPIRATION are not in use anymore.