### PR TITLE
Add configure.ac to Git ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config.status
 config.sub
 configure
 configure.in
+configure.ac
 conftest
 conftest.c
 include


### PR DESCRIPTION
The configure.ac is used since PHP 7.2 and the updated build system instead of the old configure.in file which is still used in PHP 7.1 and lower versions.

These files are generated during the phpize...

Thank you.