### PR TITLE
Remove forgotten unused comment about -lpthread

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -253,7 +253,6 @@ if test "$PHP_MEMCACHED" != "no"; then
     PHP_EVAL_LIBLINE($PHP_LIBMEMCACHED_LIBS, MEMCACHED_SHARED_LIBADD)
     PHP_EVAL_INCLINE($PHP_LIBMEMCACHED_INCLUDES)
 
-    dnl # Added -lpthread here because AC_TRY_LINK tests on CentOS 6 seem to fail with undefined reference to pthread_once
     ORIG_CFLAGS="$CFLAGS"
     CFLAGS="$CFLAGS $INCLUDES"
 


### PR DESCRIPTION
The -lpthread option has been added long time ago in commit
c10de3699faa3ecb4cb6861d6c92157e0c7e18ce

and has been since also refactored and therefore comment is not needed anymore:
feed35e22040b874ba6fc8659dc16b498e6e4150

Thanks for considering merging this or checking it out...