### PR TITLE
Fixing homebrew ZLIB  path.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -60,7 +60,7 @@ if test "$PHP_MEMCACHED" != "no"; then
       AC_MSG_ERROR([Can't find ZLIB headers under "$PHP_ZLIB_DIR"])
     fi
   else
-    for i in /usr/local /usr; do
+    for i in /usr/local /usr/local/opt/zlib /usr; do
       if test -f "$i/include/zlib/zlib.h"; then
         PHP_ZLIB_DIR="$i"
         PHP_ZLIB_INCDIR="$i/include/zlib"


### PR DESCRIPTION
In the latest zlib package for homebrew, the install target is /usr/local/opt/zlib, so I'm adding that to the list.