### PR TITLE
First pass at using simple memcached_get when possible

### DIFF
--- a/tests/experimental/get_udp.phpt
+++ b/tests/experimental/get_udp.phpt
@@ -4,42 +4,43 @@ Memcached::set()/delete() UDP
 <?php include dirname(dirname(__FILE__)) . "/skipif.inc";?>
 --FILE--
 <?php
-include dirname(dirname(__FILE__)) . '/config.inc';
-$m = memc_get_instance ();
-
+include dirname(dirname(__FILE__)) . "/config.inc";
 $m_udp = new Memcached();
 $m_udp->setOption(Memcached::OPT_USE_UDP, true);
-$m_udp->addServer('127.0.0.1', 11211, 1);
+$m_udp->addServer("127.0.0.1", 11211, 1);
 
-
-
-error_reporting(0);
-
-echo "\n";
-echo "Delete not found\n";
-$m->delete('foo');
-var_dump($m_udp->delete('foo'));
+echo "\nGet incompatible\n";
+var_dump($m_udp->get("foo", null, Memcached::GET_EXTENDED));
 echo $m_udp->getResultMessage(), "\n";
 
-echo "\n";
-echo "Set\n";
-var_dump($m_udp->set('foo', "asdf", 10));
-sleep (1);
-
+echo "\nDelete not found\n";
+$m_udp->delete("foo");
+var_dump($m_udp->delete("foo"));
 echo $m_udp->getResultMessage(), "\n";
-var_dump($m->get('foo'));
 
-echo "\n";
-echo "Delete found\n";
-var_dump($m_udp->delete('foo'));
-sleep (1);
-
+echo "\nSet\n";
+var_dump($m_udp->set("foo", "asdf", 10));
 echo $m_udp->getResultMessage(), "\n";
-$m->get('foo');
-echo $m->getResultMessage(), "\n";
 
+echo "\nGet found\n";
+var_dump($m_udp->get("foo"));
+echo $m_udp->getResultMessage(), "\n";
 
---EXPECT--
+echo "\nDelete found\n";
+var_dump($m_udp->delete("foo"));
+echo $m_udp->getResultMessage(), "\n";
+
+echo "\nGet not found\n";
+$m_udp->get("foo");
+echo $m_udp->getResultMessage(), "\n";
+
+echo "\nOK\n";
+
+--EXPECTF--
+Get incompatible
+
+Warning: Memcached::get(): Cannot use GET_EXTENDED in UDP mode in %s on line %d
+
 Delete not found
 bool(true)
 SUCCESS
@@ -47,9 +48,16 @@ SUCCESS
 Set
 bool(true)
 SUCCESS
+
+Get found
 string(4) "asdf"
+SUCCESS
 
 Delete found
 bool(true)
 SUCCESS
+
+Get not found
 NOT FOUND
+
+OK


### PR DESCRIPTION
In binary mode, memcached_mget always issues two packets, which ends up
making it slower than ascii mode for many users.

This commit incorrectly believes that libmemcached supports UDP get, it
does not, so that assumption needs to be reworked. Maybe UDP mode should
automatically make both a TCP and a UDP connection? Or return a class
with fewer methods so that it can be introspected or used with a magic
method not defined to fall back to a TCP connection class as needed?