### PR TITLE
Update documented default for sess_lock_retries

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -15,8 +15,8 @@
 ;memcached.sess_lock_wait_max = 150;
 
 ; The number of times to retry locking the session lock, not including the first attempt.
-; Default is 200.
-;memcached.sess_lock_retries = 200;
+; Default is 5.
+;memcached.sess_lock_retries = 5;
 
 ; The time, in seconds, before a lock should release itself.
 ; Setting to 0 results in the default behaviour, which is to


### PR DESCRIPTION
The documented default was 200, while in reality it seems this is actually set to 5. While 5 is arguably on the low side, at least have the documentation in sync with reality.

See here: https://github.com/php-memcached-dev/php-memcached/blob/e7ac9225abd0f6660927fa89585634caf4a76f44/php_memcached.c#L374