### PR TITLE
Remove stray instances of TSRMLS_CC macro

### DIFF
--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -67,8 +67,9 @@ function install_libmemcached() {
 }
 
 function install_igbinary() {
-    git clone https://github.com/igbinary/igbinary.git
+    git clone https://github.com/sodabrew/igbinary.git
     pushd igbinary
+        git checkout php-8
         phpize
         ./configure
         make

--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -445,7 +445,7 @@ PS_READ_FUNC(memcached)
 		*val = ZSTR_EMPTY_ALLOC();
 		return SUCCESS;
 	} else {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error getting session from memcached: %s", memcached_last_error_message(memc));
+		php_error_docref(NULL, E_WARNING, "error getting session from memcached: %s", memcached_last_error_message(memc));
 		return FAILURE;
 	}
 }
@@ -475,7 +475,7 @@ PS_WRITE_FUNC(memcached)
 		if (memcached_set(memc, key->val, key->len, val->val, val->len, expiration, 0) == MEMCACHED_SUCCESS) {
 			return SUCCESS;
 		} else {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "error saving session to memcached: %s", memcached_last_error_message(memc));
+			php_error_docref(NULL, E_WARNING, "error saving session to memcached: %s", memcached_last_error_message(memc));
 		}
 	} while (--retries > 0);
 


### PR DESCRIPTION
This macro was defined empty in PHP 7.x, and removed in PHP 8.x.

Resolves #443 