### PR TITLE
Fix build with PHP 7.4

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3234,7 +3234,7 @@ static PHP_METHOD(Memcached, setOptions)
 	zval *options;
 	zend_bool ok = 1;
 	zend_string *key;
-	ulong key_index;
+	zend_ulong key_index;
 	zval *value;
 
 	MEMC_METHOD_INIT_VARS;


### PR DESCRIPTION
Build error on FreeBSD with PHP 7.4 RC6:
```
--- php_memcached.lo ---
/wrkdirs/usr/ports/databases/pecl-memcached/work-php74/memcached-3.1.4/php_memcached.c:3237:7: error: expected ';' after expression
        ulong key_index;
             ^
             ;
/wrkdirs/usr/ports/databases/pecl-memcached/work-php74/memcached-3.1.4/php_memcached.c:3237:2: error: use of undeclared identifier 'ulong'
        ulong key_index;
        ^
/wrkdirs/usr/ports/databases/pecl-memcached/work-php74/memcached-3.1.4/php_memcached.c:3237:8: error: use of undeclared identifier 'key_index'
        ulong key_index;
              ^
/wrkdirs/usr/ports/databases/pecl-memcached/work-php74/memcached-3.1.4/php_memcached.c:3250:49: error: use of undeclared identifier 'key_index'
        ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(options), key_index, key, value) {
                                                       ^
/wrkdirs/usr/ports/databases/pecl-memcached/work-php74/memcached-3.1.4/php_memcached.c:3255:44: error: use of undeclared identifier 'key_index'
                        if (!php_memc_set_option(intern, (long) key_index, value)) {
                                                                ^
5 errors generated.
*** [php_memcached.lo] Error code 1
```