### PR TITLE
MOD: don't re-set the libmemcached option if not modified

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3111,6 +3111,11 @@ int php_memc_set_option(php_memc_object_t *intern, long option, zval *value)
 				lval = zval_get_long(value);
 
 				if (flag < MEMCACHED_BEHAVIOR_MAX) {
+					// don't reset the option when the option value wasn't modified,
+					// while the libmemcached may shutdown all connections.
+					if (memcached_behavior_get(intern->memc, flag) == (uint64_t)lval) {
+						return 1;
+					}
 					rc = memcached_behavior_set(intern->memc, flag, (uint64_t)lval);
 				}
 				else {


### PR DESCRIPTION
libmemcached would close all connections if the option(like MEMCACHED_BEHAVIOR_BINARY_PROTOCOL) was set, even though the value wasn't modified. If the user uses the setOptions in the wrong way may cause the persistent connection never works.