### PR TITLE
FIX: store_retry_count shouldn't be set implicitly

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -131,8 +131,8 @@
 ; This mechanism allows transparent fail-over to secondary servers when
 ; set/increment/decrement/setMulti operations fail on the desired server in a multi-server
 ; environment.
-; the default is 2
-;memcached.store_retry_count = 2
+; the default is 0
+;memcached.store_retry_count = 0
 
 ; Sets the default for consistent hashing for new connections.
 ; (To configure consistent hashing for session connections,

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -401,7 +401,7 @@ PHP_INI_BEGIN()
 	MEMC_INI_ENTRY("compression_factor",    "1.3",                   OnUpdateReal,            compression_factor)
 	MEMC_INI_ENTRY("compression_threshold", "2000",                  OnUpdateLong,            compression_threshold)
 	MEMC_INI_ENTRY("serializer",            SERIALIZER_DEFAULT_NAME, OnUpdateSerializer,      serializer_name)
-	MEMC_INI_ENTRY("store_retry_count",     "2",                     OnUpdateLong,            store_retry_count)
+	MEMC_INI_ENTRY("store_retry_count",     "0",                     OnUpdateLong,            store_retry_count)
 
 	MEMC_INI_BOOL ("default_consistent_hash",       "0", OnUpdateBool,       default_behavior.consistent_hash_enabled)
 	MEMC_INI_BOOL ("default_binary_protocol",       "0", OnUpdateBool,       default_behavior.binary_protocol_enabled)


### PR DESCRIPTION
It's wired that store commands would be auto-retry implicitly while the default value of store_retry_count was 2, as well as the timeout, would be 3 times in those store commands which may confuse users. IMHO, the retry should be set explicitly instead of implicitly.