### PR TITLE
Fix memcached.ini comment - remove reference to old config name (#456)

### DIFF
--- a/memcached.ini
+++ b/memcached.ini
@@ -85,7 +85,6 @@
 
 ; Session SASL username
 ; Both username and password need to be set for SASL to be enabled
-; In addition to this memcached.use_sasl needs to be on
 ;memcached.sess_sasl_username = NULL
 
 ; Session SASL password


### PR DESCRIPTION
Fix a small typo.

`memcached.use_sasl` config name [seems not used](https://github.com/php-memcached-dev/php-memcached/blob/ed3f39d07e08517e68acdbf57304da1328d7adac/php_memcached_session.c#L226) anymore.