### PR TITLE
PHP 7.4 is no longer in "snapshot"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 language: php
 php:
     - master
-    - 7.4snapshot
+    - 7.4
     - 7.3
     - 7.2
     - 7.1
@@ -34,5 +34,5 @@ script:
     - ./.travis/travis.sh script $LIBMEMCACHED_VERSION
 
 cache:
-    directories: 
+    directories:
     - $HOME/cache


### PR DESCRIPTION
Removing `snapshot` ensures the latest version of PHP 7.4.x is always used. `7.4snapshot` seems to have been stuck on `7.4.3-dev` (see [latest build output](https://travis-ci.org/github/php-memcached-dev/php-memcached/jobs/661023934)).