### PR TITLE
fix build for php 8.0

### DIFF
--- a/php_memcached_server.c
+++ b/php_memcached_server.c
@@ -63,7 +63,9 @@ long s_invoke_php_callback (php_memc_server_cb_t *cb, zval *params, ssize_t para
 	cb->fci.retval = retval;
 	cb->fci.params = params;
 	cb->fci.param_count = param_count;
+#if PHP_VERSION_ID < 80000
 	cb->fci.no_separation = 1;
+#endif
 
 	if (zend_call_function(&(cb->fci), &(cb->fci_cache)) == FAILURE) {
 		char *buf = php_memc_printable_func(&(cb->fci), &(cb->fci_cache));


### PR DESCRIPTION
no_separation removed on php 8.0