### PR TITLE
Add PHP 8.0 to the Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ dist: xenial
 
 language: php
 php:
-    - master
+    - nightly
+    - 8.0
     - 7.4
     - 7.3
     - 7.2
@@ -12,7 +13,7 @@ php:
 matrix:
     fast_finish: true
     allow_failures:
-        - php: master
+        - php: nightly
 
 env:
     - LIBMEMCACHED_VERSION=1.0.18 # Debian Jessie / Ubuntu Xenial


### PR DESCRIPTION
This will be separate from the `master` entry, which will always be tracking the next version.