### PR TITLE
missing header for inet_ntoa

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -392,6 +392,8 @@ if test "$PHP_MEMCACHED" != "no"; then
 
     CFLAGS="$ORIG_CFLAGS"
 
+    AC_CHECK_HEADERS([arpa/inet.h])
+
     export PKG_CONFIG_PATH="$ORIG_PKG_CONFIG_PATH"
     PHP_SUBST(MEMCACHED_SHARED_LIBADD)
 

--- a/php_memcached_server.c
+++ b/php_memcached_server.c
@@ -17,6 +17,9 @@
 #include "php_memcached.h"
 #include "php_memcached_private.h"
 #include "php_memcached_server.h"
+#if HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
 
 #include <event2/listener.h>
 


### PR DESCRIPTION
To avoid

```
In file included from /opt/remi/php80/root/usr/include/php/main/php.h:35,
                 from /dev/shm/BUILD/php80-php-pecl-memcached-3.1.5/NTS/php_memcached.h:20,
                 from /dev/shm/BUILD/php80-php-pecl-memcached-3.1.5/NTS/php_memcached_server.c:17:
/dev/shm/BUILD/php80-php-pecl-memcached-3.1.5/NTS/php_memcached_server.c: In function 's_handle_memcached_event':
/dev/shm/BUILD/php80-php-pecl-memcached-3.1.5/NTS/php_memcached_server.c:592:29: warning: implicit declaration of function 'inet_ntoa' [-Wimplicit-function-declaration]
  592 |     ZVAL_STRING(&zremoteip, inet_ntoa (addr_in.sin_addr));
      |                             ^~~~~~~~~
/opt/remi/php80/root/usr/include/php/Zend/zend_API.h:657:21: note: in definition of macro 'ZVAL_STRING'
  657 |   const char *_s = (s);     \
      |                     ^
/opt/remi/php80/root/usr/include/php/Zend/zend_API.h:657:20: warning: initialization of 'const char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  657 |   const char *_s = (s);     \
      |                    ^
/dev/shm/BUILD/php80-php-pecl-memcached-3.1.5/NTS/php_memcached_server.c:592:5: note: in expansion of macro 'ZVAL_STRING'
  592 |     ZVAL_STRING(&zremoteip, inet_ntoa (addr_in.sin_addr));
   
```   |     ^~~~~~~~~~~
