### PR TITLE
Don't expect tests/expire to fail

### DIFF
--- a/tests/expire.phpt
+++ b/tests/expire.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Memcached store, fetch & touch expired key
---XFAIL--
-https://code.google.com/p/memcached/issues/detail?id=275
 --SKIPIF--
 <?php
 $min_version = "1.4.8";


### PR DESCRIPTION
The issue reported in https://code.google.com/archive/p/memcached/issues/275 was fixed more than 8 years ago and the test is no longer expected to fail