### PR TITLE
Fix issue raised by PHP 8.1

### DIFF
--- a/tests/undefined_set.phpt
+++ b/tests/undefined_set.phpt
@@ -10,30 +10,25 @@ $m = memc_get_instance ();
 $key = 'foobarbazDEADC0DE';
 $value = array('foo' => 'bar');
 
-$rv = $m->set($no_key, $value, 360);
+// silent to hide:
+// Warning: Undefined variable
+// Deprecated: Memcached::set(): Passing null to parameter (PHP 8.1)
+
+$rv = @$m->set($no_key, $value, 360);
 var_dump($rv);
 
 
-$rv = $m->set($key, $no_value, 360);
+$rv = @$m->set($key, $no_value, 360);
 var_dump($rv);
 
-$rv = $m->set($no_key, $no_value, 360);
+$rv = @$m->set($no_key, $no_value, 360);
 var_dump($rv);
 
-$rv = $m->set($key, $value, $no_time);
+$rv = @$m->set($key, $value, $no_time);
 var_dump($rv);
 ?>
 --EXPECTF--
-%s: Undefined variable%sno_key in %s
 bool(false)
-
-%s: Undefined variable%sno_value in %s
 bool(true)
-
-%s: Undefined variable%sno_key in %s
-
-%s: Undefined variable%sno_value in %s
 bool(false)
-
-%s: Undefined variable%sno_time in %s
 bool(true)


### PR DESCRIPTION
1st commit fix bad param count raising funny message

`Fatal error: Uncaught TypeError: Memcached::setMulti(): Argument #2 ($expiration) **must be of type int, int given** in `/work/GIT/pecl-and-ext/memcached/tests/cas_multi.php:14````

2nd hides deprecation warning