### PR TITLE
Improve phpinfo information

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -4300,7 +4300,22 @@ PHP_MINFO_FUNCTION(memcached)
 	php_info_print_table_start();
 	php_info_print_table_header(2, "memcached support", "enabled");
 	php_info_print_table_row(2, "Version", PHP_MEMCACHED_VERSION);
-	php_info_print_table_row(2, "libmemcached version", memcached_lib_version());
+
+#ifdef LIBMEMCACHED_AWESOME
+	if (strcmp(LIBMEMCACHED_VERSION_STRING, memcached_lib_version())) {
+		php_info_print_table_row(2, "libmemcached-awesome headers version", LIBMEMCACHED_VERSION_STRING);
+		php_info_print_table_row(2, "libmemcached-awesome library version", memcached_lib_version());
+	} else {
+		php_info_print_table_row(2, "libmemcached-awesome version", memcached_lib_version());
+	}
+#else
+	if (strcmp(LIBMEMCACHED_VERSION_STRING, memcached_lib_version())) {
+		php_info_print_table_row(2, "libmemcached headers version", LIBMEMCACHED_VERSION_STRING);
+		php_info_print_table_row(2, "libmemcached library version", memcached_lib_version());
+	} else {
+		php_info_print_table_row(2, "libmemcached version", memcached_lib_version());
+	}
+#endif
 
 #ifdef HAVE_MEMCACHED_SASL
 	php_info_print_table_row(2, "SASL support", "yes");


### PR DESCRIPTION
- display libmemcached-awesome when used (since 1.1.1)
- display both builtime and runtime versions when different

Ex: 

```
$ php --ri memcached

memcached

memcached support => enabled
Version => 3.1.5
libmemcached-awesome version => 1.1.1
...

$ php --ri memcached

memcached

memcached support => enabled
Version => 3.1.5
libmemcached-awesome headers version => 1.1.0
libmemcached-awesome library version => 1.1.1
...

```