### PR TITLE
Remove "failed to set key" warning from setMulti

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -1907,9 +1907,8 @@ static void php_memc_setMulti_impl(INTERNAL_FUNCTION_PARAMETERS, zend_bool by_ke
 			str_key = zend_string_init(tmp_key, tmp_len, 0);
 		}
 
-		if (!s_memc_write_zval (intern, MEMC_OP_SET, server_key, str_key, value, expiration)) {
-			php_error_docref(NULL, E_WARNING, "failed to set key %s", ZSTR_VAL(str_key));
-		}
+		/* If this failed to write a value, intern stores the error for the return value */
+		s_memc_write_zval (intern, MEMC_OP_SET, server_key, str_key, value, expiration);
 
 		if (!skey) {
 			zend_string_release (str_key);

--- a/tests/experimental/setmulti_badserialize.phpt
+++ b/tests/experimental/setmulti_badserialize.phpt
@@ -42,6 +42,5 @@ try {
 var_dump($m->getByKey('kef', 'foo'));
 
 --EXPECT--
-Memcached::setMultiByKey(): failed to set key foo
 1234
 int(10)


### PR DESCRIPTION
This was introduced in https://github.com/php-memcached-dev/php-memcached/commit/6837d89494, pull https://github.com/php-memcached-dev/php-memcached/pull/214. I suspect it may have been a left-over from debugging something. The test was later changed in 6837d89494 to expect the warning in question, although other similar tests don't encounter such warning currently.

It appears no other Memcached methods emit a PHP Warning when they encounter a write read or failure. Instead, they typically turn their return value into boolean false, and provide details via getResultMessage().

The introduction of this warning since php-memcached 3.0 has led to a number of confused consumers (locally #260, #409, #450, and more reports within downstream issue trackers).

Closes https://github.com/php-memcached-dev/php-memcached/issues/409.