### PR TITLE
Remove experimental for PHP 8.1 and add PHP 8.2 experimental

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,11 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         experimental: [false]
-        include:
-          - php: '8.1'
-            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,9 @@ jobs:
       matrix:
         php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         experimental: [false]
+        include:
+          - php: '8.2'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Given that PHP 8.1 will be released within 2 weeks I think it's good to fail instead of skip.

Added PHP 8.2 as experimental :)