### PR TITLE
Fix MSVC builds wrt. ssize_t

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -36,7 +36,7 @@ if (PHP_MEMCACHED == "yes") {
 	  }
   }
   
-  EXTENSION("memcached", "php_memcached.c php_libmemcached_compat.c g_fmt.c"+memcached_extra_src);
+  EXTENSION("memcached", "php_memcached.c php_libmemcached_compat.c g_fmt.c"+memcached_extra_src, null, " /DHAVE_SSIZE_T");
   ADD_SOURCES(configure_module_dirname+"\\fastlz", "fastlz.c", "memcached");
   AC_DEFINE("HAVE_MEMCACHED", 1, "memcached support");
   AC_DEFINE("MEMCACHED_EXPORTS", 1)


### PR DESCRIPTION
The Windows SDK does not define `ssize_t`, so libmemcached does not
define `HAVE_SSIZE_T`.  However, PHP's config.w32.h has
`#define ssize_t SSIZE_T`, so building memcached fails.  We fix this by
defining `HAVE_SSIZE_T` via the extension's `CFLAGS`.