### PR TITLE
Add minimal Windows CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,37 @@
+name: Build on Windows
+on: [push, pull_request]
+jobs:
+  windows:
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      matrix:
+          version: ['7.4', '8.0', '8.1']
+          arch: [x64, x86]
+          ts: [nts, zts]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout memcached
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        id: setup-php
+        uses: cmb69/setup-php-sdk@v0.7
+        with:
+          version: ${{matrix.version}}
+          arch: ${{matrix.arch}}
+          ts: ${{matrix.ts}}
+          deps: zlib
+      - name: Fetch libmemcached
+        run: curl -OLs https://windows.php.net/downloads/pecl/deps/libmemcached-1.1.1-${{steps.setup-php.outputs.vs}}-${{matrix.arch}}.zip && 7z x libmemcached-1.1.1-${{steps.setup-php.outputs.vs}}-${{matrix.arch}}.zip -o..\deps
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{matrix.arch}}
+          toolset: ${{steps.setup-php.outputs.toolset}}
+      - name: phpize
+        run: phpize
+      - name: configure
+        run: configure --enable-memcached --enable-memcached-session --enable-memcached-json --with-prefix=${{steps.setup-php.outputs.prefix}}
+      - name: make
+        run: nmake


### PR DESCRIPTION
For now, only building the extension is supported.

---

I've did that as separate action, but of course it could be merged into the existing action for Linux. And of course, the matrix could be extended regarding the PHP versions; as is, 7.2 up to 8.2 should be supported.

Note that the libmemcached dependency is hard-coded, since cmb69/setup-php-sdk does not yet support fetching PECL dependencies.

Unrelated to this PR: there is no check in config.w32 for zlib; that is no problem for in-tree extension builds, but can be for phpize builds; if desired, I can provide a PR to add that check.