### PR TITLE
If client-side verify_key is not enabled, don't check it automatically

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -246,6 +246,7 @@ zend_bool s_memc_valid_key_ascii(zend_string *key)
 #define MEMC_CHECK_KEY(intern, key)                                               \
 	if (UNEXPECTED(ZSTR_LEN(key) == 0 ||                                          \
 		ZSTR_LEN(key) > MEMC_OBJECT_KEY_MAX_LENGTH ||                             \
+		memcached_behavior_get(intern->memc, MEMCACHED_BEHAVIOR_VERIFY_KEY) &&    \
 		(memcached_behavior_get(intern->memc, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL) \
 				? !s_memc_valid_key_binary(key)                                   \
 				: !s_memc_valid_key_ascii(key)                                    \

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -246,10 +246,9 @@ zend_bool s_memc_valid_key_ascii(zend_string *key)
 #define MEMC_CHECK_KEY(intern, key)                                               \
 	if (UNEXPECTED(ZSTR_LEN(key) == 0 ||                                          \
 		ZSTR_LEN(key) > MEMC_OBJECT_KEY_MAX_LENGTH ||                             \
-		memcached_behavior_get(intern->memc, MEMCACHED_BEHAVIOR_VERIFY_KEY) &&    \
 		(memcached_behavior_get(intern->memc, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL) \
 				? !s_memc_valid_key_binary(key)                                   \
-				: !s_memc_valid_key_ascii(key)                                    \
+				: (memcached_behavior_get(intern->memc, MEMCACHED_BEHAVIOR_VERIFY_KEY) && !s_memc_valid_key_ascii(key)) \
 		))) {                                                                     \
 		intern->rescode = MEMCACHED_BAD_KEY_PROVIDED;                             \
 		RETURN_FALSE;                                                             \

--- a/tests/cas_invalid_key.phpt
+++ b/tests/cas_invalid_key.phpt
@@ -5,7 +5,10 @@ Memcached::cas() with strange key
 --FILE--
 <?php
 include dirname(__FILE__) . '/config.inc';
-$m = memc_get_instance ();
+$m = memc_get_instance (array (
+    Memcached::OPT_BINARY_PROTOCOL => false,
+    Memcached::OPT_VERIFY_KEY => true
+));
 
 error_reporting(0);
 var_dump($m->cas(0, '', true, 10));

--- a/tests/delete_bykey.phpt
+++ b/tests/delete_bykey.phpt
@@ -5,7 +5,10 @@ Memcached::deleteByKey()
 --FILE--
 <?php
 include dirname(__FILE__) . '/config.inc';
-$m = memc_get_instance ();
+$m = memc_get_instance (array (
+    Memcached::OPT_BINARY_PROTOCOL => false,
+    Memcached::OPT_VERIFY_KEY => true
+));
 
 $m->setByKey('keffe', 'eisaleeoo', "foo");
 var_dump($m->getByKey('keffe', 'eisaleeoo'));

--- a/tests/get.phpt
+++ b/tests/get.phpt
@@ -5,7 +5,10 @@ Memcached::get()
 --FILE--
 <?php
 include dirname(__FILE__) . '/config.inc';
-$m = memc_get_instance ();
+$m = memc_get_instance (array (
+    Memcached::OPT_BINARY_PROTOCOL => false,
+    Memcached::OPT_VERIFY_KEY => true
+));
 
 $m->delete('foo');
 

--- a/tests/keys_ascii.phpt
+++ b/tests/keys_ascii.phpt
@@ -8,11 +8,8 @@ Test valid and invalid keys - ascii
 include dirname (__FILE__) . '/config.inc';
 $ascii = memc_get_instance (array (
 				Memcached::OPT_BINARY_PROTOCOL => false,
-				Memcached::OPT_VERIFY_KEY => false
+				Memcached::OPT_VERIFY_KEY => true
 		));
-// libmemcached can verify keys, but these are tests are for our own
-// function s_memc_valid_key_ascii, so explicitly disable the checks
-// that libmemcached can perform.
 
 echo 'ASCII: SPACES' . PHP_EOL;
 var_dump ($ascii->set ('ascii key with spaces', 'this is a test'));


### PR DESCRIPTION
libmemcached's key verification is only done if OPT_VERIFY_KEY is enabled. We should honour this setting in the PHP extension as well and not do it automatically.
This addresses https://github.com/php-memcached-dev/php-memcached/issues/546

Note that I am still not completely sold on making this change.