### PR TITLE
The key length check was not taking the prefix into account

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -231,6 +231,19 @@ zend_bool s_memc_valid_key_binary(zend_string *key)
 }
 
 static
+uint32_t s_memc_object_key_max_length(php_memc_object_t *intern) {
+	memcached_return retval;
+	char *result;
+
+	result = memcached_callback_get(intern->memc, MEMCACHED_CALLBACK_PREFIX_KEY, &retval);
+	if (retval == MEMCACHED_SUCCESS && result) {
+		return MEMC_OBJECT_KEY_MAX_LENGTH - strlen(result);
+	} else {
+		return MEMC_OBJECT_KEY_MAX_LENGTH;
+	}
+}
+
+static
 zend_bool s_memc_valid_key_ascii(zend_string *key)
 {
 	const char *str = ZSTR_VAL(key);
@@ -245,7 +258,7 @@ zend_bool s_memc_valid_key_ascii(zend_string *key)
 
 #define MEMC_CHECK_KEY(intern, key)                                               \
 	if (UNEXPECTED(ZSTR_LEN(key) == 0 ||                                          \
-		ZSTR_LEN(key) > MEMC_OBJECT_KEY_MAX_LENGTH ||                             \
+		ZSTR_LEN(key) > s_memc_object_key_max_length(intern) ||                   \
 		(memcached_behavior_get(intern->memc, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL) \
 				? !s_memc_valid_key_binary(key)                                   \
 				: !s_memc_valid_key_ascii(key)                                    \


### PR DESCRIPTION
The `MEMC_CHECK_KEY` macro meant to make sure keys are valid was not taking a prefix into account when checking the length of the key. This is especially important to get right in case NOREPLY sets are used on a persistent connection because the server will send a parser error back on a long key and the client is not expecting a reply which in turn messes up subsequent requests on this persistent connection.