### PR TITLE
use zend_ce_exception

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3961,7 +3961,7 @@ zend_class_entry *php_memc_get_exception_base(int root)
 		}
 	}
 
-	return zend_exception_get_default();
+	return zend_ce_exception;
 }
 
 


### PR DESCRIPTION
As `zend_exception_get_default` was removed in 8.5
