### PR TITLE
Add configure option --with-zstd to package.xml for PECL

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -213,6 +213,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
   <configureoption name="with-libmemcached-dir"     prompt="libmemcached directory"     default="no"/>
   <configureoption name="with-zlib-dir"             prompt="zlib directory"             default="no"/>
   <configureoption name="with-system-fastlz"        prompt="use system fastlz"          default="no"/>
+  <configureoption name="with-zstd"                 prompt="use system zstd library"    default="no"/>
   <configureoption name="enable-memcached-igbinary" prompt="enable igbinary serializer" default="no"/>
   <configureoption name="enable-memcached-msgpack"  prompt="enable msgpack serializer"  default="no"/>
   <configureoption name="enable-memcached-json"     prompt="enable json serializer"     default="no"/>


### PR DESCRIPTION
This adds the missing configure option --with-zstd to package.xml 