### PR TITLE
Fix -Wstrict-prototypes warnings

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -516,7 +516,7 @@ static
   Exported helper functions
 ****************************************/
 
-zend_bool php_memc_init_sasl_if_needed()
+zend_bool php_memc_init_sasl_if_needed(void)
 {
 #ifdef HAVE_MEMCACHED_SASL
 	if (MEMC_G(sasl_initialised)) {

--- a/php_memcached_private.h
+++ b/php_memcached_private.h
@@ -245,7 +245,7 @@ char *php_memc_printable_func (zend_fcall_info *fci, zend_fcall_info_cache *fci_
 
 memcached_return php_memcached_exist (memcached_st *memc, zend_string *key);
 
-zend_bool php_memc_init_sasl_if_needed();
+zend_bool php_memc_init_sasl_if_needed(void);
 
 #endif /* PHP_MEMCACHED_PRIVATE_H */
 

--- a/php_memcached_server.c
+++ b/php_memcached_server.c
@@ -714,7 +714,7 @@ void s_accept_cb (evutil_socket_t fd, short what, void *arg)
 	}
 }
 
-php_memc_proto_handler_t *php_memc_proto_handler_new ()
+php_memc_proto_handler_t *php_memc_proto_handler_new (void)
 {
 	php_memc_proto_handler_t *handler = ecalloc (1, sizeof (php_memc_proto_handler_t));
 

--- a/php_memcached_server.h
+++ b/php_memcached_server.h
@@ -29,7 +29,7 @@ typedef struct _php_memc_proto_handler_t php_memc_proto_handler_t;
 /*
 	Functions
 */
-php_memc_proto_handler_t *php_memc_proto_handler_new ();
+php_memc_proto_handler_t *php_memc_proto_handler_new (void);
 
 void php_memc_proto_handler_destroy (php_memc_proto_handler_t **ptr);
 

--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -96,7 +96,7 @@ time_t s_adjust_expiration(zend_long expiration)
 }
 
 static
-time_t s_lock_expiration()
+time_t s_lock_expiration(void)
 {
 	if (MEMC_SESS_INI(lock_expiration) > 0) {
 		return s_adjust_expiration(MEMC_SESS_INI(lock_expiration));


### PR DESCRIPTION
LLVM warns about function declarations without a prototype being "deprecated in all versions of C"